### PR TITLE
fix(platform/alz): add `Deploy-MDFC-DefSQL-AMA` to default `ama_user_assigned_managed_identity_id`

### DIFF
--- a/platform/alz/README.md
+++ b/platform/alz/README.md
@@ -450,6 +450,13 @@ The following policy default values are available in this library:
   
 ### default name `ama_user_assigned_managed_identity_id`
   
+#### assignment `Deploy-MDFC-DefSQL-AMA`
+  
+<details><summary>1 parameter names</summary>
+
+- userAssignedIdentityResourceId
+</details>
+  
 #### assignment `Deploy-VM-ChangeTrack`
   
 <details><summary>1 parameter names</summary>

--- a/platform/alz/alz_policy_default_values.json
+++ b/platform/alz/alz_policy_default_values.json
@@ -27,6 +27,12 @@
           "parameter_names": [
             "userAssignedIdentityResourceId"
           ]
+        },
+        {
+          "policy_assignment_name": "Deploy-MDFC-DefSQL-AMA",
+          "parameter_names": [
+            "userAssignedIdentityResourceId"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Default for Deploy-MDFC-DefSQL-AMA is missing userAssignedIdentityResourceId by @JWilkinsonMB

Fixes Azure/Azure-Landing-Zones#1677