### PR TITLE
Fix metadata docs for go-getter reference

### DIFF
--- a/docs/content/assets/metadata.md
+++ b/docs/content/assets/metadata.md
@@ -50,7 +50,7 @@ These are defined by the library path and reference (version):
 {
   "dependencies": [
     {
-      "custom_url": "git::https://github.com/myorg/myrepo.git//mypath@mytag",
+      "custom_url": "git::https://github.com/myorg/myrepo.git//mypath/subdir?ref=mytag-or-branch",
     }
   ]
 }


### PR DESCRIPTION
This pull request includes a small change to the `docs/content/assets/metadata.md` file. The change updates the `custom_url` to point to a subdirectory and allows specifying a tag or branch.

* [`docs/content/assets/metadata.md`](diffhunk://#diff-e55fa9541d13865e4d860a6374e238a2488595dcc7b44af4797a80d2ed0c019bL53-R53): Updated the `custom_url` to point to a subdirectory and allow specifying a tag or branch.