### PR TITLE
ci: use repo var for alzlibtool

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,9 +12,6 @@ on:
       - main
   workflow_dispatch:
 
-env:
-  alzlibtool_version: "0.23.0"
-
 jobs:
   libschanged:
     runs-on: ubuntu-latest
@@ -53,7 +50,7 @@ jobs:
     steps:
       - name: Install alzlibtool
         run: |
-          curl -L https://github.com/Azure/alzlib/releases/download/v${{ env.alzlibtool_version }}/alzlibtool_linux_amd64.tar.gz | tar -xvz
+          curl -L https://github.com/Azure/alzlib/releases/download/${{ vars.ALZLIBTOOL_VERSION }}/alzlibtool_linux_amd64.tar.gz | tar -xvz
           sudo cp alzlibtool /usr/local/bin
 
       - name: Checkout code

--- a/.github/workflows/update-alz.yml
+++ b/.github/workflows/update-alz.yml
@@ -11,7 +11,6 @@ permissions:
   contents: write
 
 env:
-  alzlibtool_version: "0.23.0"
   remote_repository: "Azure/Enterprise-Scale"
   alzlib_repository: "Azure/alzlib"
   library_dir: "platform/alz"
@@ -28,7 +27,7 @@ jobs:
     steps:
       - name: Install alzlibtool
         run: |
-          curl -L https://github.com/Azure/alzlib/releases/download/v${{ env.alzlibtool_version }}/alzlibtool_linux_amd64.tar.gz | tar -xvz
+          curl -L https://github.com/Azure/alzlib/releases/download/${{ vars.ALZLIBTOOL_VERSION }}/alzlibtool_linux_amd64.tar.gz | tar -xvz
           sudo cp alzlibtool /usr/local/bin
 
       - name: Local repository checkout


### PR DESCRIPTION
Keeps things consistent over multiple actions by using a repo var for the version of alzlibtool