### PR TITLE
fix: Update Enforce-Encryption-CMK.alz_policy_set_definition.json effect

### DIFF
--- a/platform/alz/policy_set_definitions/Enforce-Encryption-CMK.alz_policy_set_definition.json
+++ b/platform/alz/policy_set_definitions/Enforce-Encryption-CMK.alz_policy_set_definition.json
@@ -71,11 +71,10 @@
       },
       "CognitiveServicesCMKEffect": {
         "allowedValues": [
-          "Audit",
-          "Deny",
+          "AuditIfNotExists",
           "Disabled"
         ],
-        "defaultValue": "Deny",
+        "defaultValue": "AuditIfNotExists",
         "metadata": {
           "description": "Customer-managed keys (CMK) are commonly required to meet regulatory compliance standards. CMKs enable the data stored in Cognitive Services to be encrypted with an Azure Key Vault key created and owned by you. You have full control and responsibility for the key lifecycle, including rotation and management. Learn more about CMK encryption at https://aka.ms/cosmosdb-cmk.",
           "displayName": "Cognitive Services accounts should enable data encryption with a customer-managed key (CMK)"


### PR DESCRIPTION
Fixes https://github.com/Azure/Azure-Landing-Zones/issues/2612

This pull request includes a change to the `platform/alz/policy_set_definitions/Enforce-Encryption-CMK.alz_policy_set_definition.json` file. The change updates the allowed values and default value for the `CognitiveServicesCMKEffect` property to improve regulatory compliance and control over data encryption.

Key changes:

* Updated the allowed values for the `CognitiveServicesCMKEffect` property to include "AuditIfNotExists" and removed "Deny".
* Changed the default value for the `CognitiveServicesCMKEffect` property from "Deny" to "AuditIfNotExists".