### PR TITLE
Update ALZ lib to 2025.02.0 for SLZ and FSI.

### DIFF
--- a/platform/fsi/alz_library_metadata.json
+++ b/platform/fsi/alz_library_metadata.json
@@ -7,7 +7,7 @@
   "dependencies": [
     {
       "path": "platform/alz",
-      "ref": "2024.07.4"
+      "ref": "2025.02.0"
     }
   ]
 }

--- a/platform/slz/alz_library_metadata.json
+++ b/platform/slz/alz_library_metadata.json
@@ -7,7 +7,7 @@
   "dependencies": [
     {
       "path": "platform/alz",
-      "ref": "2024.07.02"
+      "ref": "2025.02.0"
     }
   ]
 }


### PR DESCRIPTION
Update ALZ lib to 2025.02.0 for SLZ and FSI.