### PR TITLE
chore: bump alzlibtool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ALZ_LIB_TOOL_VERSION := v0.25.2
+ALZ_LIB_TOOL_VERSION := v0.28.3
 
 .PHONY: server tools docs docs-check lib-check
 server:


### PR DESCRIPTION
Bumps tool so that it picks up a greater number of misconfigurations