### PR TITLE
fix: Change Deny-Priv-Esc-AKS effect default

### DIFF
--- a/platform/alz/policy_assignments/Deny-Priv-Esc-AKS.alz_policy_assignment.json
+++ b/platform/alz/policy_assignments/Deny-Priv-Esc-AKS.alz_policy_assignment.json
@@ -11,7 +11,7 @@
     "enforcementMode": "Default",
     "parameters": {
       "effect": {
-        "value": "deny"
+        "value": "Deny"
       }
     },
     "scope": "/providers/Microsoft.Management/managementGroups/placeholder",


### PR DESCRIPTION
This pull request contains a minor update to the `Deny-Priv-Esc-AKS.alz_policy_assignment.json` policy assignment. The change standardizes the value of the `effect` parameter by updating its casing from "deny" to "Deny" which occurred in version[ 8.0.0](https://www.azadvertizer.net/azpolicyadvertizer/1c6e92c9-99f0-4e55-9cf2-0c234dc48f99.html) of the policy definition. 

* Standardized the `effect` parameter value from "deny" to "Deny" in `Deny-Priv-Esc-AKS.alz_policy_assignment.json` to ensure consistency with Azure Policy conventions.