### PR TITLE
Align archetype name and id and rename alz to root

### DIFF
--- a/platform/alz/README.md
+++ b/platform/alz/README.md
@@ -19,28 +19,28 @@ provider "alz" {
   
 The following architectures are available in this library, please note that the diagrams denote the management group display name and, in brackets, the associated archetypes:
   
-### architecture `alz`
+### architecture `root`
   
 > [!NOTE]  
 > This hierarchy will be deployed as a child of the user-supplied root management group.
   
 ```mermaid
 flowchart TD
-  alz["Azure Landing Zones
+  root["Azure Landing Zones
 (root)"]
-  alz --> decommissioned
+  root --> decommissioned
   decommissioned["Decommissioned
 (decommissioned)"]
-  alz --> landingzones
+  root --> landingzones
   landingzones["Landing zones
-(landing_zones)"]
+(landingzones)"]
   landingzones --> corp
   corp["Corp
 (corp)"]
   landingzones --> online
   online["Online
 (online)"]
-  alz --> platform
+  root --> platform
   platform["Platform
 (platform)"]
   platform --> connectivity
@@ -55,7 +55,7 @@ flowchart TD
   platform --> security
   security["Security
 (security)"]
-  alz --> sandbox
+  root --> sandbox
   sandbox["Sandbox
 (sandbox)"]
 
@@ -106,9 +106,9 @@ flowchart TD
 - Deploy-VM-Backup
 </details>
   
-### archetype `landing_zones`
+### archetype `landingzones`
   
-#### landing_zones policy assignments
+#### landingzones policy assignments
   
 <details><summary>53 policy assignments</summary>
 

--- a/platform/alz/archetype_definitions/landing_zones.alz_archetype_definition.json
+++ b/platform/alz/archetype_definitions/landing_zones.alz_archetype_definition.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/Azure/Azure-Landing-Zones-Library/main/schemas/archetype_definition.json",
-  "name": "landing_zones",
+  "name": "landingzones",
   "policy_assignments": [
     "Audit-AppGW-WAF",
     "Deny-IP-forwarding",

--- a/platform/alz/architecture_definitions/alz.alz_architecture_definition.json
+++ b/platform/alz/architecture_definitions/alz.alz_architecture_definition.json
@@ -8,7 +8,7 @@
       ],
       "display_name": "Azure Landing Zones",
       "exists": false,
-      "id": "alz",
+      "id": "root",
       "parent_id": null
     },
     {
@@ -22,7 +22,7 @@
     },
     {
       "archetypes": [
-        "landing_zones"
+        "landingzones"
       ],
       "display_name": "Landing zones",
       "exists": false,

--- a/platform/amba/README.md
+++ b/platform/amba/README.md
@@ -26,12 +26,12 @@ The following architectures are available in this library, please note that the 
   
 ```mermaid
 flowchart TD
-  alz["Azure Landing Zones
+  root["Azure Landing Zones
 (amba_root)"]
-  alz --> landingzones
+  root --> landingzones
   landingzones["Landing zones
 (amba_landing_zones)"]
-  alz --> platform
+  root --> platform
   platform["Platform
 (amba_platform)"]
   platform --> connectivity

--- a/platform/slz/README.md
+++ b/platform/slz/README.md
@@ -30,21 +30,21 @@ The following architectures are available in this library, please note that the 
   
 ```mermaid
 flowchart TD
-  alz["Azure Landing Zones
+  root["Azure Landing Zones
 (root)"]
-  alz --> decommissioned
+  root --> decommissioned
   decommissioned["Decommissioned
 (decommissioned)"]
-  alz --> landingzones
+  root --> landingzones
   landingzones["Landing zones
-(landing_zones)"]
+(landingzones)"]
   landingzones --> corp
   corp["Corp
 (corp)"]
   landingzones --> online
   online["Online
 (online)"]
-  alz --> platform
+  root --> platform
   platform["Platform
 (platform)"]
   platform --> connectivity
@@ -59,7 +59,7 @@ flowchart TD
   platform --> security
   security["Security
 (security)"]
-  alz --> sandbox
+  root --> sandbox
   sandbox["Sandbox
 (sandbox)"]
 
@@ -179,9 +179,9 @@ flowchart TD
 - Deploy-VM-Backup
 </details>
   
-### archetype `landing_zones`
+### archetype `landingzones`
   
-#### landing_zones policy assignments
+#### landingzones policy assignments
   
 <details><summary>53 policy assignments</summary>
 


### PR DESCRIPTION
Renaming Azure Landing Zones id from 'alz' to 'root' and aligning all archetype names to the id for alignment