### PR TITLE
chore: Update ALZ_LIB_TOOL_VERSION to v0.29.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ALZ_LIB_TOOL_VERSION := v0.29.1
+ALZ_LIB_TOOL_VERSION := v0.29.3
 
 .PHONY: server tools docs docs-check lib-check
 server:


### PR DESCRIPTION
This pull request updates the version of a tool used in the build process. The change is limited to the `Makefile` and bumps the `ALZ_LIB_TOOL_VERSION` from `v0.29.1` to `v0.29.3`.