### PR TITLE
fix: enhance library update workflow with reset option+ add file renaming functionality to PowerShell script for ALZ to handle versioning + alter lib diff check in pr-check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,7 +25,7 @@ jobs:
         id: libs
         run: |
           DIFF="$(git diff --name-only origin/${{ github.base_ref }} | xargs dirname | sort | uniq)"
-          LIBDIFFPRE="$(echo "${DIFF}" | grep '^platform/' || true)"
+          LIBDIFFPRE="$(echo "${DIFF}" | grep '^platform/' | grep -v '/scripts' || true)"
 
           LIBDIFF=()
           for folder in ${LIBDIFFPRE};

--- a/.github/workflows/update-alz.yml
+++ b/.github/workflows/update-alz.yml
@@ -5,7 +5,12 @@ name: update platform/alz
 on:
   schedule:
     - cron: "0 8 * * 1"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      reset:
+        description: "Reset the library by deleting existing artifacts before update"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -82,7 +87,7 @@ jobs:
             Write-Information "==> Running policy definitions in archetype definitions script..." -InformationAction Continue
             ${{ github.repository }}/platform/alz/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1 `
               -TargetPath "${{ github.workspace }}/${{ github.repository }}" `
-              -SourcePath "${{ github.workspace }}/${{ env.remote_repository }}"
+              -SourcePath "${{ github.workspace }}/${{ env.remote_repository }}" ${{ inputs.reset == true && '-Reset' || '' }}
           azPSVersion: "latest"
 
       - name: update library policy assignments and archetypes

--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -2,7 +2,7 @@
 
 #
 # PowerShell Script
-# - Update template library in terraform-azurerm-caf-enterprise-scale repository
+# - Update template library in azure-landing-zones-library repository
 #
 
 [CmdletBinding(SupportsShouldProcess)]


### PR DESCRIPTION
This pull request introduces several improvements to the Azure Landing Zones (ALZ) library update workflows and scripts. The main changes include enhanced file naming conventions for policy artifacts, better support for resetting the library during updates, and improved script messaging for clarity. Additionally, documentation in script headers has been updated to reflect the current repository name.

**Workflow and Automation Improvements:**

* Added a `reset` boolean input to the `update-alz.yml` workflow, allowing users to delete all existing artifacts before updating the library. The workflow now passes this parameter to the update script, enabling full library resets when needed. [[1]](diffhunk://#diff-30b4761dedce48cb162dc5973712c43fd0556bd84d522f753333e88dd8d8cedcL8-R13) [[2]](diffhunk://#diff-30b4761dedce48cb162dc5973712c43fd0556bd84d522f753333e88dd8d8cedcL85-R90)
* Improved the logic in the `pr-check.yml` workflow to exclude changes in `/scripts` directories from library diff checks, reducing unnecessary triggers.

**Policy Artifact Management Enhancements:**

* Introduced a new `Rename-LibraryFile` function in `Invoke-LibraryUpdatePolicyDefinitions.ps1` to enforce consistent naming conventions for policy definition and policy set definition files, using the format `{name}.{version}.{fileType}.json` or `{name}.{fileType}.json`. The script now automatically renames files as needed after updates. [[1]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bR31-R58) [[2]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL62-R134)
* Improved messaging and clarity in the update scripts by making log outputs more descriptive and consistent, especially around deletion and renaming operations. [[1]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL42-R80) [[2]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL62-R134)

**Documentation Updates:**

* Updated script headers in `Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1` and `Invoke-LibraryUpdatePolicyDefinitions.ps1` to reference the correct repository name (`azure-landing-zones-library` instead of the old name). [[1]](diffhunk://#diff-c65b6ccd69ec7dc53fa9ab40389295238777e269edc66486c244971e6bc65d29L5-R5) [[2]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL5-R5)