### PR TITLE
fix: alz library script for versioning 

### DIFF
--- a/.github/workflows/update-alz.yml
+++ b/.github/workflows/update-alz.yml
@@ -93,9 +93,8 @@ jobs:
         with:
           inlineScript: |
             Write-Information "==> Running policy definitions in archetype definitions script..." -InformationAction Continue
-            ${{ github.repository }}/platform/alz/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1 `
-              -TargetPath "${{ github.workspace }}/${{ github.repository }}" `
-              -SourcePath "${{ github.workspace }}/${{ env.remote_repository }}"
+            ${{ github.repository }}/${{ env.library_dir }}/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1 `
+              -TargetPath "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}"
           azPSVersion: "latest"
 
       - name: update library policy assignments and archetypes

--- a/.github/workflows/update-alz.yml
+++ b/.github/workflows/update-alz.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       reset:
-        description: "Reset the library by deleting existing policy defs and policy set defs before update"
+        description: "Reset the library by deleting existing policy files before update"
         type: boolean
         default: false
 
@@ -74,7 +74,9 @@ jobs:
           echo "Deleting existing Policy Definitions from library."
           rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_definitions/"*.json
           echo "Deleting existing Policy Set Definitions from library."
-          rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_set_definitions/"*.json
+          rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_set_definitions/"*.
+          echo "Deleting existing Policy Assignments from library."
+          rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_assignments/"*.json
 
       - name: update library policy definitions
         run: |

--- a/.github/workflows/update-alz.yml
+++ b/.github/workflows/update-alz.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       reset:
-        description: "Reset the library by deleting existing artifacts before update"
+        description: "Reset the library by deleting existing policy defs and policy set defs before update"
         type: boolean
         default: false
 
@@ -68,6 +68,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
+      - name: reset library artifacts
+        if: ${{ inputs.reset == true }}
+        run: |
+          echo "Deleting existing Policy Definitions from library."
+          rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_definitions/"*.json
+          echo "Deleting existing Policy Set Definitions from library."
+          rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_set_definitions/"*.json
+
       - name: update library policy definitions
         run: |
           alzlibtool convert policydefinition -o \
@@ -87,7 +95,7 @@ jobs:
             Write-Information "==> Running policy definitions in archetype definitions script..." -InformationAction Continue
             ${{ github.repository }}/platform/alz/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1 `
               -TargetPath "${{ github.workspace }}/${{ github.repository }}" `
-              -SourcePath "${{ github.workspace }}/${{ env.remote_repository }}" ${{ inputs.reset == true && '-Reset' || '' }}
+              -SourcePath "${{ github.workspace }}/${{ env.remote_repository }}"
           azPSVersion: "latest"
 
       - name: update library policy assignments and archetypes

--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1
@@ -24,7 +24,6 @@ param (
   [Parameter()][String]$TargetPath = "$PWD/library/platform/alz",
   [Parameter()][String]$SourcePath = "$PWD/enterprise-scale",
   [Parameter()][String]$LineEnding = "unix",
-  [Parameter()][Switch]$Reset,
   [Parameter()][Switch]$UpdateProviderApiVersions
 )
 
@@ -64,18 +63,9 @@ $removedPolicySetDefinitions = @(
 
 $removedPolicyDefinitions = @()
 
-# If the -Reset parameter is set, delete all existing
-# artefacts (by resource type) from the library
-if ($Reset) {
-  Write-Information "=====> Deleting existing Policy Definitions from library." -InformationAction Continue
-  Remove-Item -Path "$TargetPath/platform/alz/policy_definitions/" -Recurse -Force
-  Write-Information "=====> Deleting existing Policy Set Definitions from library." -InformationAction Continue
-  Remove-Item -Path "$TargetPath/platform/alz/policy_set_definitions/" -Recurse -Force
-}
-
 # Remove any Policy Set Definitions that are no longer
 # present in the source repository
-Get-ChildItem -Path "$TargetPath/platform/alz/policy_set_definitions/" -File | ForEach-Object {
+Get-ChildItem -Path (Join-Path $TargetPath "policy_set_definitions") -File | ForEach-Object {
   if ($removedPolicySetDefinitions -contains $_.Name) {
     Write-Information "==> Removing obsolete Policy Set Definition: $($_.Name)" -InformationAction Continue
     Remove-Item -Path $_.FullName -Force
@@ -84,8 +74,7 @@ Get-ChildItem -Path "$TargetPath/platform/alz/policy_set_definitions/" -File | F
 
 # Remove any Policy Definitions that are no longer
 # present in the source repository
-Get-ChildItem -Path "$TargetPath/platform/alz/policy_definitions/" -File
-| ForEach-Object {
+Get-ChildItem -Path (Join-Path $TargetPath "policy_definitions") -File | ForEach-Object {
   if ($removedPolicyDefinitions -contains $_.Name) {
     Write-Information "==> Removing obsolete Policy Definition: $($_.Name)" -InformationAction Continue
     Remove-Item -Path $_.FullName -Force
@@ -107,13 +96,13 @@ Get-ChildItem -Path "$TargetPath/platform/alz/policy_set_definitions/" -File -Fi
 }
 
 # Get a list of current Policy Definition names
-$policyDefinitionFiles = Get-ChildItem -Path "$TargetPath/platform/alz/policy_definitions/"
+$policyDefinitionFiles = Get-ChildItem -Path (Join-Path $TargetPath "policy_definitions") -File
 $policyDefinitionNames = $policyDefinitionFiles | ForEach-Object {
   (Get-Content -Path $_ | ConvertFrom-Json).name
 }
 
 # Get a list of current Policy Set Definition names
-$policySetDefinitionFiles = Get-ChildItem -Path "$TargetPath/platform/alz/policy_set_definitions/"
+$policySetDefinitionFiles = Get-ChildItem -Path (Join-Path $TargetPath "policy_set_definitions") -File
 $policySetDefinitionNames = $policySetDefinitionFiles | ForEach-Object {
   (Get-Content -Path $_ | ConvertFrom-Json).name
 }
@@ -121,7 +110,7 @@ $policySetDefinitionNames = $policySetDefinitionFiles | ForEach-Object {
 # Update the es_root archetype definition to reflect
 # the current list of Policy Definitions and Policy
 # Set Definitions
-$esRootFilePath = $TargetPath + "/platform/alz/archetype_definitions/root.alz_archetype_definition.json"
+$esRootFilePath = Join-Path $TargetPath "archetype_definitions/root.alz_archetype_definition.json"
 Write-Information "=====> Loading `"root`" archetype definition." -InformationAction Continue
 $esRootConfig = Get-Content -Path $esRootFilePath | ConvertFrom-Json
 Write-Information "=====> Updating Policy Definitions in `"root`" archetype definition." -InformationAction Continue

--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyDefinitions.ps1
@@ -21,10 +21,7 @@
 
 [CmdletBinding(SupportsShouldProcess)]
 param (
-  [Parameter()][String]$TargetPath = "$PWD/library/platform/alz",
-  [Parameter()][String]$SourcePath = "$PWD/enterprise-scale",
-  [Parameter()][String]$LineEnding = "unix",
-  [Parameter()][Switch]$UpdateProviderApiVersions
+  [Parameter()][String]$TargetPath = "$PWD/library/platform/alz"  
 )
 
 # Functions
@@ -83,14 +80,14 @@ Get-ChildItem -Path (Join-Path $TargetPath "policy_definitions") -File | ForEach
 
 # Rename Policy Definition files to match naming convention
 Write-Information "=====> Checking Policy Definition file names." -InformationAction Continue
-Get-ChildItem -Path "$TargetPath/platform/alz/policy_definitions/" -File -Filter "*.json" | ForEach-Object {
+Get-ChildItem -Path (Join-Path $TargetPath "policy_definitions") -File -Filter "*.json" | ForEach-Object {
   Write-Information "==> Processing file: $($_.FullName) for versioning naming." -InformationAction Continue
   Rename-LibraryFile -File $_ -FileType "alz_policy_definition"
 }
 
 # Rename Policy Set Definition files to match naming convention
 Write-Information "=====> Checking Policy Set Definition file names." -InformationAction Continue
-Get-ChildItem -Path "$TargetPath/platform/alz/policy_set_definitions/" -File -Filter "*.json" | ForEach-Object {
+Get-ChildItem -Path (Join-Path $TargetPath "policy_set_definitions") -File -Filter "*.json" | ForEach-Object {
   Write-Information "==> Processing file: $($_.FullName) for versioning naming." -InformationAction Continue
   Rename-LibraryFile -File $_ -FileType "alz_policy_set_definition"
 }


### PR DESCRIPTION
This pull request updates the workflow and PowerShell script for updating ALZ policy library artifacts, focusing on improving file handling, path management, and reset behavior. The changes enhance reliability, make file operations safer, and streamline the process for deleting and renaming policy files.

**Workflow and Script Improvements:**

*Improved Reset Behavior:*
- The workflow's reset option now specifically deletes only policy definitions and policy set definitions, rather than all artifacts, and updates the description for clarity. [[1]](diffhunk://#diff-30b4761dedce48cb162dc5973712c43fd0556bd84d522f753333e88dd8d8cedcL11-R11) [[2]](diffhunk://#diff-30b4761dedce48cb162dc5973712c43fd0556bd84d522f753333e88dd8d8cedcR71-R78)
- The PowerShell script removes the `-Reset` parameter and associated logic, delegating reset operations to the workflow layer for clearer separation of responsibilities. [[1]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL24-R24) [[2]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL67-R91)

*File Handling and Naming:*
- The `Rename-LibraryFile` function now checks if a file already has the correct name and skips unnecessary renames. If a target file exists, it compares file contents (normalized as JSON); if identical, it removes the duplicate, otherwise it overwrites the target. This prevents redundant operations and ensures consistency.
- All file and directory paths in the script are now constructed using `Join-Path`, making path handling more robust and cross-platform. [[1]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL87-R100) [[2]](diffhunk://#diff-fb739c375795ece92a23c8e02a816793ced6e2c727de76455aa053e11cfe2e4bL97-R136)

*Removed unnecessary parameters*
- Various parameters removed from the powershell script as not used and left behind from the past

*Workflow Script Invocation:*
- The workflow now calls the update script using the correct library directory path from the environment variable, ensuring it operates on the intended files.

### Test evidence

https://github.com/Azure/Azure-Landing-Zones-Library/actions/runs/21226355648