### PR TITLE
fix: update ascExportResourceGroupName handling in policy assignment parsing

### DIFF
--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -153,7 +153,8 @@ $policyAssignmentTargetPath = "$TargetPath/platform/alz/policy_assignments"
 
 # Tempalting regex to identify any remaining tempalting values
 # Optionally, the preceeding '-?' allows for removal of any leading '-' characters
-$templatingRegex = '-?\${[^}]+}'
+# Uses negative lookahead to preserve ${default_location}
+$templatingRegex = '-?\${(?!default_location\})[^}]+}'
 
 foreach ($managementGroup in $policyAssignments.Keys) {
   $managementGroupNameFinal = $managementGroupMapping[$managementGroup.Replace("defaults-", "")]

--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -247,7 +247,7 @@ foreach ($managementGroup in $policyAssignments.Keys) {
         # Remove any futher templating values
         if ($parsedAssignment.properties.parameters.($propertyName).value -match $templatingRegex) {
           Write-Verbose "Removing templating from parameter: $propertyName"
-          $parsedAssignment.properties.($propertyName).value = $parsedAssignment.properties.($propertyName).value -replace $templatingRegex
+          $parsedAssignment.properties.parameters.($propertyName).value = $parsedAssignment.properties.parameters.($propertyName).value -replace $templatingRegex
         }
       }
 

--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -237,6 +237,9 @@ foreach ($managementGroup in $policyAssignments.Keys) {
         if ($parsedAssignment.properties.parameters.($propertyName).value.StartsWith("`${temp}")) {
           $parsedAssignment.properties.parameters.($propertyName).value = $parsedAssignment.properties.parameters.($propertyName).value.Replace("`${temp}", "/providers/Microsoft.Management/managementGroups/placeholder")
         }
+        if ($propertyName -eq "ascExportResourceGroupName" -and $parsedAssignment.properties.parameters.($propertyName).value.StartsWith("rg-mdfc-export-prod-${temp}")) {
+          $parsedAssignment.properties.parameters.($propertyName).value = "rg-mdfc-export-prod"
+        }
       }
 
       $targetPolicyAssignmentFileName = $policyAssignmentName + ".alz_policy_assignment.json"

--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -151,6 +151,10 @@ $finalPolicyAssignments = New-Object 'System.Collections.Generic.Dictionary[stri
 $policyAssignmentSourcePath = "$SourcePath/eslzArm/managementGroupTemplates/policyAssignments"
 $policyAssignmentTargetPath = "$TargetPath/platform/alz/policy_assignments"
 
+# Tempalting regex to identify any remaining tempalting values
+# Optionally, the preceeding '-?' allows for removal of any leading '-' characters
+$templatingRegex = '-?\${[^}]+}'
+
 foreach ($managementGroup in $policyAssignments.Keys) {
   $managementGroupNameFinal = $managementGroupMapping[$managementGroup.Replace("defaults-", "")]
   Write-Output "`nProcessing Archetype Policy Assignments for Management Group: $managementGroupNameFinal"
@@ -234,11 +238,16 @@ foreach ($managementGroup in $policyAssignments.Keys) {
           $parsedAssignment.properties.parameters.($propertyName).value = $parsedAssignment.properties.parameters.($propertyName).value.Replace("`${private_dns_zone_prefix}/providers/Microsoft.Network/privateDnsZones/", "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/placeholder/providers/Microsoft.Network/privateDnsZones/")
           # $parsedAssignment.properties.parameters.($propertyName).value = $parsedAssignment.properties.parameters.($propertyName).value.Replace("privatelink.uks.backup.windowsazure.com", "privatelink.`${connectivity_location_short}.backup.windowsazure.com")
         }
+
+        # If the parameter starts with ${temp}, replace with placeholder management group
         if ($parsedAssignment.properties.parameters.($propertyName).value.StartsWith("`${temp}")) {
           $parsedAssignment.properties.parameters.($propertyName).value = $parsedAssignment.properties.parameters.($propertyName).value.Replace("`${temp}", "/providers/Microsoft.Management/managementGroups/placeholder")
         }
-        if ($propertyName -eq "ascExportResourceGroupName" -and $parsedAssignment.properties.parameters.($propertyName).value.StartsWith("rg-mdfc-export-prod-${temp}")) {
-          $parsedAssignment.properties.parameters.($propertyName).value = "rg-mdfc-export-prod"
+        
+        # Remove any futher templating values
+        if ($parsedAssignment.properties.parameters.($propertyName).value -match $templatingRegex) {
+          Write-Verbose "Removing templating from parameter: $propertyName"
+          $parsedAssignment.properties.($propertyName).value = $parsedAssignment.properties.($propertyName).value -replace $templatingRegex
         }
       }
 


### PR DESCRIPTION
This pull request introduces a targeted fix for handling a specific parameter value in the policy assignment script. The change ensures that the `ascExportResourceGroupName` parameter is set to a consistent value when it matches a certain pattern.

**Parameter handling improvement:**

* Updated the script to check if the `ascExportResourceGroupName` parameter starts with `rg-mdfc-export-prod-${temp}` and, if so, set its value to `rg-mdfc-export-prod` to ensure consistency in resource group naming.

### Testing 

https://github.com/Azure/Azure-Landing-Zones-Library/pull/280/changes#diff-2a5bd5da7011a0ddb4f200c75c4cfa45772c94238140b8a774dcb2099f7fa885