### PR TITLE
feat: update SLZ assignments

### DIFF
--- a/platform/slz/README.md
+++ b/platform/slz/README.md
@@ -82,10 +82,10 @@ flowchart TD
 (landing_zones)"]
   landingzones --> confidential_corp
   confidential_corp["Confidential Corp
-(confidential_corp)"]
+(confidential_corp, corp)"]
   landingzones --> confidential_online
   confidential_online["Confidential Online
-(confidential_online)"]
+(confidential_online, online)"]
   landingzones --> corp
   corp["Corp
 (corp)"]
@@ -286,6 +286,15 @@ flowchart TD
 - Enforce-GR-Synapse0
 - Enforce-GR-VirtualDesk0
 - Enforce-Subnet-Private
+</details>
+  
+### archetype `public`
+  
+#### public policy assignments
+  
+<details><summary>1 policy assignments</summary>
+
+- Deny-L3-IP-Routing
 </details>
   
 ### archetype `root`
@@ -907,7 +916,7 @@ The subscription id that hosts the private link DNS zones.
   
 ### all policy assignments
   
-<details><summary>82 policy assignments</summary>
+<details><summary>83 policy assignments</summary>
 
 - Audit-AppGW-WAF
 - Audit-PeDnsZones
@@ -918,6 +927,7 @@ The subscription id that hosts the private link DNS zones.
 - Deny-Classic-Resources
 - Deny-HybridNetworking
 - Deny-IP-forwarding
+- Deny-L3-IP-Routing
 - Deny-MgmtPorts-Internet
 - Deny-Priv-Esc-AKS
 - Deny-Privileged-AKS

--- a/platform/slz/archetype_definitions/public.alz_archetype_definition.json
+++ b/platform/slz/archetype_definitions/public.alz_archetype_definition.json
@@ -1,6 +1,8 @@
 {
   "name": "public",
-  "policy_assignments": [],
+  "policy_assignments": [
+    "Deny-L3-IP-Routing"
+  ],
   "policy_definitions": [],
   "policy_set_definitions": [],
   "role_definitions": []

--- a/platform/slz/architecture_definitions/slz.alz_architecture_definition.json
+++ b/platform/slz/architecture_definitions/slz.alz_architecture_definition.json
@@ -69,7 +69,7 @@
     },
     {
       "archetypes": [
-        "oneline",
+        "online",
         "confidential_online"
       ],
       "display_name": "Confidential Online",

--- a/platform/slz/architecture_definitions/slz.alz_architecture_definition.json
+++ b/platform/slz/architecture_definitions/slz.alz_architecture_definition.json
@@ -59,6 +59,7 @@
     },
     {
       "archetypes": [
+        "corp",
         "confidential_corp"
       ],
       "display_name": "Confidential Corp",
@@ -68,6 +69,7 @@
     },
     {
       "archetypes": [
+        "oneline",
         "confidential_online"
       ],
       "display_name": "Confidential Online",

--- a/platform/slz/policy_assignments/Deny-L3-IP-Routing.alz_policy_assignment.json
+++ b/platform/slz/policy_assignments/Deny-L3-IP-Routing.alz_policy_assignment.json
@@ -1,0 +1,44 @@
+{
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2024-04-01",
+  "name": "Deny-L3-IP-Routing",
+  "location": "${default_location}",
+  "dependsOn": [],
+  "identity": {
+    "type": "None"
+  },
+  "properties": {
+    "description": "This initiative assignment will prevent the creation of network resources that enable Layer 3 IP routing, such as ExpressRoute circuits and gateways, Virtual WANs and Hubs, VPN gateways, and P2S VPN gateways. It will also prevent vNet Peering cross Subscription. This is to ensure that the subscriptions remain isolated and do not have connectivity to on-premises or other virtual networks.",
+    "displayName": "Deny Layer 3 IP Routing and vNet Peering cross subscription",
+    "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/placeholder/providers/Microsoft.Authorization/policySetDefinitions/Enforce-ALZ-Sandbox",
+    "enforcementMode": "Default",
+    "nonComplianceMessages": [
+      {
+        "message": "Creation of network resources that enable Layer 3 IP routing or vNet Peering outside of the same subscription is not allowed."
+      }
+    ],
+    "parameters": {
+      "listOfResourceTypesNotAllowed": {
+        "value": [
+          "microsoft.network/expressroutecircuits",
+          "microsoft.network/expressroutegateways",
+          "microsoft.network/expressrouteports",
+          "microsoft.network/virtualwans",
+          "microsoft.network/virtualhubs",
+          "microsoft.network/vpngateways",
+          "microsoft.network/p2svpngateways",
+          "microsoft.network/vpnsites",
+          "microsoft.network/virtualnetworkgateways"
+        ]
+      },
+      "effectNotAllowedResources": {
+        "value": "Deny"
+      },
+      "effectDenyVnetPeering": {
+        "value": "Deny"
+      }
+    },
+    "scope": "/providers/Microsoft.Management/managementGroups/placeholder",
+    "notScopes": []
+  }
+}


### PR DESCRIPTION
This pull request introduces a new network security policy assignment, `Deny-L3-IP-Routing`, to the `public` archetype and updates documentation and architecture definitions to reflect this addition. The main goal is to strengthen network isolation by preventing the creation of Layer 3 IP routing resources and cross-subscription vNet peering in public environments.

**Policy and Archetype Updates:**

* Added new policy assignment definition file for `Deny-L3-IP-Routing`, which blocks creation of network resources enabling Layer 3 IP routing and vNet peering across subscriptions (`platform/slz/policy_assignments/Deny-L3-IP-Routing.alz_policy_assignment.json`).
* Updated `public` archetype to include the new `Deny-L3-IP-Routing` policy assignment (`platform/slz/archetype_definitions/public.alz_archetype_definition.json`).

**Documentation and Architecture Changes:**

* Updated architecture definitions to explicitly list `corp` and `online` archetypes for "Confidential Corp" and "Confidential Online" environments (`platform/slz/architecture_definitions/slz.alz_architecture_definition.json`). [[1]](diffhunk://#diff-c4c5027866d69304e0e9d19a3ac3992d040ed04e5883d6d7d58e2a0d12f284c7R62) [[2]](diffhunk://#diff-c4c5027866d69304e0e9d19a3ac3992d040ed04e5883d6d7d58e2a0d12f284c7R72)
* Improved flowchart and documentation in `platform/slz/README.md` to reflect new archetype relationships and the addition of the new policy assignment (`Deny-L3-IP-Routing`), including updating policy assignment counts and lists. [[1]](diffhunk://#diff-e4df9f73804c6b28a25ef40a4526c93cf73f825b5eac5c47cd0ff49fb48612bfL85-R88) [[2]](diffhunk://#diff-e4df9f73804c6b28a25ef40a4526c93cf73f825b5eac5c47cd0ff49fb48612bfR291-R299) [[3]](diffhunk://#diff-e4df9f73804c6b28a25ef40a4526c93cf73f825b5eac5c47cd0ff49fb48612bfL910-R919) [[4]](diffhunk://#diff-e4df9f73804c6b28a25ef40a4526c93cf73f825b5eac5c47cd0ff49fb48612bfR930)