### PR TITLE
feat: add policy default values for resource group location, names, and security contact

### DIFF
--- a/platform/alz/README.md
+++ b/platform/alz/README.md
@@ -548,6 +548,15 @@ The DDoS protection plan id that should be used for the DDoS protection plan dep
 | Enable-DDoS-VNET | ddosPlan        |
 
   
+### default name `email_security_contact`
+  
+The default email address for the security contact. This is used for the Deploy-MDFC-Config-H224 policy assignment to set up the security contact in Microsoft Defender for Cloud.
+  
+|       ASSIGNMENT        |   PARAMETER NAMES    |
+|-------------------------|----------------------|
+| Deploy-MDFC-Config-H224 | emailSecurityContact |
+
+  
 ### default name `log_analytics_workspace_id`
   
 The Log Analytics workspace id that should be used for centralized log collection.
@@ -586,6 +595,34 @@ The subscription id that hosts the private link DNS zones.
 |        ASSIGNMENT        |    PARAMETER NAMES    |
 |--------------------------|-----------------------|
 | Deploy-Private-DNS-Zones | dnsZoneSubscriptionId |
+
+  
+### default name `resource_group_location`
+  
+The default location for resource groups. This is used for policies that create resource groups without a specified location.
+  
+|        ASSIGNMENT        |        PARAMETER NAMES         |
+|--------------------------|--------------------------------|
+| Deploy-MDFC-Config-H224  | ascExportResourceGroupLocation |
+| Deploy-SvcHealth-BuiltIn | resourceGroupLocation          |
+
+  
+### default name `resource_group_name_mdfc`
+  
+The default resource group name for microsoft defender for cloud export. This is used for the Deploy-MDFC-Config-H224 policy assignment to create the necessary resources.
+  
+|       ASSIGNMENT        |      PARAMETER NAMES       |
+|-------------------------|----------------------------|
+| Deploy-MDFC-Config-H224 | ascExportResourceGroupName |
+
+  
+### default name `resource_group_name_service_health_alerts`
+  
+The default resource group name for service health alerts. This is used for the Deploy-SvcHealth-BuiltIn policy assignment to create the necessary resources for service health alerting.
+  
+|        ASSIGNMENT        |  PARAMETER NAMES  |
+|--------------------------|-------------------|
+| Deploy-SvcHealth-BuiltIn | resourceGroupName |
 
   
 ---

--- a/platform/alz/alz_policy_default_values.json
+++ b/platform/alz/alz_policy_default_values.json
@@ -192,6 +192,60 @@
           "policy_assignment_name": "Deploy-MDFC-DefSQL-AMA"
         }
       ]
+    },
+    {
+      "default_name": "resource_group_location",
+      "description": "The default location for resource groups. This is used for policies that create resource groups without a specified location.",
+      "policy_assignments": [
+        {
+          "parameter_names": [
+            "ascExportResourceGroupLocation"
+          ],
+          "policy_assignment_name": "Deploy-MDFC-Config-H224"
+        },
+        {
+          "parameter_names": [
+            "resourceGroupLocation"
+          ],
+          "policy_assignment_name": "Deploy-SvcHealth-BuiltIn"
+        }
+      ]
+    },
+    {
+      "default_name": "resource_group_name_service_health_alerts",
+      "description": "The default resource group name for service health alerts. This is used for the Deploy-SvcHealth-BuiltIn policy assignment to create the necessary resources for service health alerting.",
+      "policy_assignments": [
+        {
+          "parameter_names": [
+            "resourceGroupName"
+          ],
+          "policy_assignment_name": "Deploy-SvcHealth-BuiltIn"
+        }
+      ]
+    },
+    {
+      "default_name": "resource_group_name_mdfc",
+      "description": "The default resource group name for microsoft defender for cloud export. This is used for the Deploy-MDFC-Config-H224 policy assignment to create the necessary resources.",
+      "policy_assignments": [
+        {
+          "parameter_names": [
+            "ascExportResourceGroupName"
+          ],
+          "policy_assignment_name": "Deploy-MDFC-Config-H224"
+        }
+      ]
+    },
+    {
+      "default_name": "email_security_contact",
+      "description": "The default email address for the security contact. This is used for the Deploy-MDFC-Config-H224 policy assignment to set up the security contact in Microsoft Defender for Cloud.",
+      "policy_assignments": [
+        {
+          "parameter_names": [
+            "emailSecurityContact"
+          ],
+          "policy_assignment_name": "Deploy-MDFC-Config-H224"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds four new policy default values to the ALZ policy default values configuration:

- **resource_group_location** - Default location for resource groups, used by Deploy-MDFC-Config-H224 and Deploy-SvcHealth-BuiltIn
- **resource_group_name_service_health_alerts** - Default resource group name for service health alerts (Deploy-SvcHealth-BuiltIn)
- **resource_group_name_mdfc** - Default resource group name for Microsoft Defender for Cloud export (Deploy-MDFC-Config-H224)
- **email_security_contact** - Default email address for security contact in Microsoft Defender for Cloud (Deploy-MDFC-Config-H224)