### PR TITLE
Update Enforce-EncryptTransit_20240509.alz_policy_set_definition.json

### DIFF
--- a/platform/alz/policy_set_definitions/Enforce-EncryptTransit_20240509.alz_policy_set_definition.json
+++ b/platform/alz/policy_set_definitions/Enforce-EncryptTransit_20240509.alz_policy_set_definition.json
@@ -19,11 +19,11 @@
     "parameters": {
       "AKSIngressHttpsOnlyEffect": {
         "allowedValues": [
-          "audit",
-          "deny",
-          "disabled"
+          "Audit",
+          "Deny",
+          "Disabled"
         ],
-        "defaultValue": "deny",
+        "defaultValue": "Deny",
         "metadata": {
           "description": "This policy enforces HTTPS ingress in a Kubernetes cluster. This policy is generally available for Kubernetes Service (AKS), and preview for AKS Engine and Azure Arc enabled Kubernetes. For instructions on using this policy, visit https://aka.ms/kubepolicydoc.",
           "displayName": "AKS Service. Enforce HTTPS ingress in Kubernetes cluster"


### PR DESCRIPTION
fixed typos in  AKSIngressHttpsOnlyEffect allowedValues, using lowercase letters in values that will prevent the policy to be applied causing error in terrafrom apply.