### PR TITLE
fix: rm command for policy set definitions

### DIFF
--- a/.github/workflows/update-alz.yml
+++ b/.github/workflows/update-alz.yml
@@ -74,7 +74,7 @@ jobs:
           echo "Deleting existing Policy Definitions from library."
           rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_definitions/"*.json
           echo "Deleting existing Policy Set Definitions from library."
-          rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_set_definitions/"*.
+          rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_set_definitions/"*.json
           echo "Deleting existing Policy Assignments from library."
           rm -f "${{ github.workspace }}/${{ github.repository }}/${{ env.library_dir }}/policy_assignments/"*.json
 


### PR DESCRIPTION
This pull request makes a minor fix to the `.github/workflows/update-alz.yml` workflow file. The change corrects the file extension in a command that deletes existing Policy Set Definitions from the library, ensuring only `.json` files are targeted.

- Fixed the `rm` command to properly delete only `.json` files in the `policy_set_definitions` directory in the workflow file `.github/workflows/update-alz.yml`.