### PR TITLE
Remove SystemAssigned identity from Enforce-ALDO-Services policy assignment

### DIFF
--- a/platform/alz/policy_assignments/Enforce-ALDO-Services.alz_policy_assignment.json
+++ b/platform/alz/policy_assignments/Enforce-ALDO-Services.alz_policy_assignment.json
@@ -4,9 +4,6 @@
   "name": "Enforce-ALDO-Services",
   "location": "${default_location}",
   "dependsOn": [],
-  "identity": {
-    "type": "SystemAssigned"
-  },
   "properties": {
     "description": "Audit the use of Azure services to those supported in Azure Local disconnected operations.",
     "displayName": "Audit resource types to Azure services supported in Azure Local disconnected operations",


### PR DESCRIPTION
## Description

Removes the `SystemAssigned` managed identity from the `Enforce-ALDO-Services` policy assignment.

The underlying policy set audits the use of Azure services to those supported in Azure Local disconnected operations. Since the assignment only uses `Audit` effects, it does not require a managed identity (managed identities are only needed for `DeployIfNotExists` and `Modify` effects).

## Change

- `platform/alz/policy_assignments/Enforce-ALDO-Services.alz_policy_assignment.json`: removed the `identity` block.
