### PR TITLE
fix: slz l2 policy assignments for TLS and HTTPS

### DIFF
--- a/platform/slz/policy_assignments/Enforce-Sov-L2-HTTPS.alz_policy_assignment.json
+++ b/platform/slz/policy_assignments/Enforce-Sov-L2-HTTPS.alz_policy_assignment.json
@@ -5,7 +5,7 @@
   "location": "${default_location}",
   "dependsOn": [],
   "identity": {
-    "type": "None"
+    "type": "SystemAssigned"
   },
   "properties": {
     "description": "Help restrict and audit Azure Services to use HTTPS/SSL. Helping to enforce Level 2 - Data Protection Sovereignty Controls detailed here: https://aka.ms/sovereign/controls",

--- a/platform/slz/policy_assignments/Enforce-Sov-L2-TLS.alz_policy_assignment.json
+++ b/platform/slz/policy_assignments/Enforce-Sov-L2-TLS.alz_policy_assignment.json
@@ -5,7 +5,7 @@
   "location": "${default_location}",
   "dependsOn": [],
   "identity": {
-    "type": "None"
+    "type": "SystemAssigned"
   },
   "properties": {
     "description": "Help restrict and audit the Azure Services to use the latest TLS versions. Helping to enforce Level 2 - Data Protection Sovereignty Controls detailed here: https://aka.ms/sovereign/controls",


### PR DESCRIPTION
This pull request updates the identity configuration for two Azure policy assignment files to enable system-assigned managed identities. This change will allow the policy assignments to authenticate securely with Azure resources.

Identity configuration updates:

* Changed the `identity.type` from `"None"` to `"SystemAssigned"` in `Enforce-Sov-L2-HTTPS.alz_policy_assignment.json` to enable a system-assigned managed identity for the HTTPS enforcement policy.
* Changed the `identity.type` from `"None"` to `"SystemAssigned"` in `Enforce-Sov-L2-TLS.alz_policy_assignment.json` to enable a system-assigned managed identity for the TLS enforcement policy.