### PR TITLE
feat: Remove Default Non-Compliance Messages from Assignments

### DIFF
--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -59,6 +59,7 @@ $managementGroupMapping = @{
   "sandboxes"      = "sandbox"
   "identity"       = "identity"
   "platform"       = "platform"
+  "local"          = "local"
 }
 
 foreach ($resource in $eslzArm) {
@@ -206,6 +207,10 @@ foreach ($managementGroup in $policyAssignments.Keys) {
         $parsedAssignment | Add-Member -MemberType NoteProperty -Name "location" -Value "uksouth"
       }
 
+      if (Get-Member -InputObject $parsedAssignment.properties -Name "nonComplianceMessages" -MemberType Properties) {
+        $parsedAssignment.properties.nonComplianceMessages = @()
+      }
+      
       $enforcementMode = $enforcementModeLookup[[Tuple]::Create($managementGroupNameFinal, $policyAssignmentFile)]
       # If enforcement mode is one of: Default, DoNotEnforce, or Disabled, set it on the policy assignment
       if ($enforcementMode -in @("Default", "DoNotEnforce", "Disabled")) {

--- a/platform/amba/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/amba/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -152,6 +152,10 @@ foreach ($managementGroup in $policyAssignments.Keys) {
       #     $parsedAssignment | Add-Member -MemberType NoteProperty -Name "identity" -Value @{ type = "None" }
       # }
 
+      if (Get-Member -InputObject $parsedAssignment.properties -Name "nonComplianceMessages" -MemberType Properties) {
+        $parsedAssignment.properties.nonComplianceMessages = @()
+      }
+
       if ($parsedAssignment.properties.policyDefinitionId.StartsWith("/providers/Microsoft.Management/managementGroups/`${temp}")) {
         $parsedAssignment.properties.policyDefinitionId = $parsedAssignment.properties.policyDefinitionId.Replace("/providers/Microsoft.Management/managementGroups/`${temp}", "/providers/Microsoft.Management/managementGroups/placeholder")
       }


### PR DESCRIPTION
This pull request introduces updates to the policy assignment archetype scripts in both the ALZ and AMBA platforms. The main focus is handle non-compliance messages via the respective caller modules (Terraform Provider & Bicep).

This ensures NCM's are applied consistently opposed to being managed from the library and the caller.

Changes made as part of:

- [#201](https://github.com/Azure/terraform-provider-alz/pull/201)
- [#298](https://github.com/Azure/terraform-azurerm-avm-ptn-alz/pull/298)
- 
_**We still need to add the same functionality to the Bicep side of things before this is merged as they rely on these messages**_

**Policy assignment property handling:**

* Updated both `platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1` and `platform/amba/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1` to clear the `nonComplianceMessages` property if it exists on a policy assignment, ensuring a clean state before further processing. [[1]](diffhunk://#diff-c65b6ccd69ec7dc53fa9ab40389295238777e269edc66486c244971e6bc65d29R210-R213) [[2]](diffhunk://#diff-22f08ef921e558d8846062242b964652c41b3cacdd921d5abe7ef9bf63d2b708R155-R158)