### PR TITLE
fix(amba): add Deploy-AMBA-VMSS to shared policy default values

### DIFF
--- a/platform/amba/alz_policy_default_values.json
+++ b/platform/amba/alz_policy_default_values.json
@@ -27,6 +27,12 @@
           "parameter_names": [
             "ALZManagementSubscriptionId"
           ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
+        },
+        {
+          "parameter_names": [
+            "ALZManagementSubscriptionId"
+          ],
           "policy_assignment_name": "Deploy-AMBA-Web"
         }
       ]
@@ -94,6 +100,12 @@
             "ALZMonitorResourceGroupName"
           ],
           "policy_assignment_name": "Deploy-AMBA-VM"
+        },
+        {
+          "parameter_names": [
+            "ALZMonitorResourceGroupName"
+          ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
         },
         {
           "parameter_names": [
@@ -171,6 +183,12 @@
           "parameter_names": [
             "ALZMonitorResourceGroupTags"
           ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
+        },
+        {
+          "parameter_names": [
+            "ALZMonitorResourceGroupTags"
+          ],
           "policy_assignment_name": "Deploy-AMBA-Web"
         }
       ]
@@ -243,6 +261,12 @@
           "parameter_names": [
             "ALZMonitorResourceGroupLocation"
           ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
+        },
+        {
+          "parameter_names": [
+            "ALZMonitorResourceGroupLocation"
+          ],
           "policy_assignment_name": "Deploy-AMBA-Web"
         }
       ]
@@ -268,6 +292,12 @@
             "ALZUserAssignedManagedIdentityName"
           ],
           "policy_assignment_name": "Deploy-AMBA-VM"
+        },
+        {
+          "parameter_names": [
+            "ALZUserAssignedManagedIdentityName"
+          ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
         },
         {
           "parameter_names": [
@@ -351,6 +381,12 @@
           "parameter_names": [
             "ALZMonitorDisableTagName"
           ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
+        },
+        {
+          "parameter_names": [
+            "ALZMonitorDisableTagName"
+          ],
           "policy_assignment_name": "Deploy-AMBA-Web"
         }
       ]
@@ -424,6 +460,12 @@
             "ALZMonitorDisableTagValues"
           ],
           "policy_assignment_name": "Deploy-AMBA-VM"
+        },
+        {
+          "parameter_names": [
+            "ALZMonitorDisableTagValues"
+          ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
         },
         {
           "parameter_names": [
@@ -568,6 +610,12 @@
             "BYOUserAssignedManagedIdentityResourceId"
           ],
           "policy_assignment_name": "Deploy-AMBA-VM"
+        },
+        {
+          "parameter_names": [
+            "BYOUserAssignedManagedIdentityResourceId"
+          ],
+          "policy_assignment_name": "Deploy-AMBA-VMSS"
         },
         {
           "parameter_names": [


### PR DESCRIPTION
## Description

The AMBA library now includes a new `Alerting-VMSS` policy set definition and its
corresponding `Deploy-AMBA-VMSS` policy assignment for monitoring Azure Virtual
Machine Scale Sets. This PR wires the new assignment into the shared AMBA policy
default values so that common configuration (resource group, managed identity,
disable tags, etc.) is applied consistently alongside the other AMBA assignments.

## Changes

Added `Deploy-AMBA-VMSS` to the following defaults in
`platform/amba/alz_policy_default_values.json`, matching the parameters already
shared by `Deploy-AMBA-VM`:

- `amba_alz_management_subscription_id` → `ALZManagementSubscriptionId`
- `amba_alz_resource_group_name` → `ALZMonitorResourceGroupName`
- `amba_alz_resource_group_tags` → `ALZMonitorResourceGroupTags`
- `amba_alz_resource_group_location` → `ALZMonitorResourceGroupLocation`
- `amba_alz_user_assigned_managed_identity_name` → `ALZUserAssignedManagedIdentityName`
- `amba_alz_disable_tag_name` → `ALZMonitorDisableTagName`
- `amba_alz_disable_tag_values` → `ALZMonitorDisableTagValues`
- `amba_alz_byo_user_assigned_managed_identity_id` → `BYOUserAssignedManagedIdentityResourceId`
