### PR TITLE
fix(scripts): default policy assignment location to ${default_location} placeholder

### DIFF
--- a/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/alz/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -204,9 +204,36 @@ foreach ($managementGroup in $policyAssignments.Keys) {
         $parsedAssignment.properties | Add-Member -MemberType NoteProperty -Name "parameters" -Value @{}
       }
 
-      if (!(Get-Member -InputObject $parsedAssignment -Name "location" -MemberType Properties)) {
-        $parsedAssignment | Add-Member -MemberType NoteProperty -Name "location" -Value "uksouth"
+      # Ensure the policy assignment has a top-level "location", defaulting to the
+      # templated "${default_location}" placeholder when the source template does
+      # not specify one. The placeholder is substituted with the consumer's target
+      # region at deployment time, so the library must not hardcode a region here.
+      #
+      # The location is (re)positioned immediately after the "name" property to
+      # match the library's curated convention. We rebuild the assignment as an
+      # ordered dictionary because Add-Member only appends, which would place
+      # "location" at the end and create noisy property-order diffs against the
+      # existing curated assignments.
+      $existingLocation = $null
+      if (Get-Member -InputObject $parsedAssignment -Name "location" -MemberType Properties) {
+        $existingLocation = $parsedAssignment.location
       }
+      $assignmentLocation = if ([string]::IsNullOrEmpty($existingLocation)) { '${default_location}' } else { $existingLocation }
+
+      $orderedAssignment = [ordered]@{}
+      foreach ($assignmentProperty in $parsedAssignment.PSObject.Properties) {
+        if ($assignmentProperty.Name -eq "location") {
+          continue
+        }
+        $orderedAssignment[$assignmentProperty.Name] = $assignmentProperty.Value
+        if ($assignmentProperty.Name -eq "name") {
+          $orderedAssignment["location"] = $assignmentLocation
+        }
+      }
+      if (!($orderedAssignment.Contains("location"))) {
+        $orderedAssignment["location"] = $assignmentLocation
+      }
+      $parsedAssignment = [PSCustomObject]$orderedAssignment
 
       $enforcementMode = $enforcementModeLookup[[Tuple]::Create($managementGroupNameFinal, $policyAssignmentFile)]
       # If enforcement mode is one of: Default, DoNotEnforce, or Disabled, set it on the policy assignment

--- a/platform/amba/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
+++ b/platform/amba/scripts/Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1
@@ -152,9 +152,36 @@ foreach ($managementGroup in $policyAssignments.Keys) {
         $parsedAssignment.properties | Add-Member -MemberType NoteProperty -Name "parameters" -Value @{}
       }
 
-      if (!(Get-Member -InputObject $parsedAssignment -Name "location" -MemberType Properties)) {
-        $parsedAssignment | Add-Member -MemberType NoteProperty -Name "location" -Value "uksouth"
+      # Ensure the policy assignment has a top-level "location", defaulting to the
+      # templated "${default_location}" placeholder when the source template does
+      # not specify one. The placeholder is substituted with the consumer's target
+      # region at deployment time, so the library must not hardcode a region here.
+      #
+      # The location is (re)positioned immediately after the "name" property to
+      # match the library's curated convention. We rebuild the assignment as an
+      # ordered dictionary because Add-Member only appends, which would place
+      # "location" at the end and create noisy property-order diffs against the
+      # existing curated assignments.
+      $existingLocation = $null
+      if (Get-Member -InputObject $parsedAssignment -Name "location" -MemberType Properties) {
+        $existingLocation = $parsedAssignment.location
       }
+      $assignmentLocation = if ([string]::IsNullOrEmpty($existingLocation)) { '${default_location}' } else { $existingLocation }
+
+      $orderedAssignment = [ordered]@{}
+      foreach ($assignmentProperty in $parsedAssignment.PSObject.Properties) {
+        if ($assignmentProperty.Name -eq "location") {
+          continue
+        }
+        $orderedAssignment[$assignmentProperty.Name] = $assignmentProperty.Value
+        if ($assignmentProperty.Name -eq "name") {
+          $orderedAssignment["location"] = $assignmentLocation
+        }
+      }
+      if (!($orderedAssignment.Contains("location"))) {
+        $orderedAssignment["location"] = $assignmentLocation
+      }
+      $parsedAssignment = [PSCustomObject]$orderedAssignment
 
       # if (!(Get-Member -InputObject $parsedAssignment -Name "identity" -MemberType Properties)) {
       #     $parsedAssignment | Add-Member -MemberType NoteProperty -Name "identity" -Value @{ type = "None" }


### PR DESCRIPTION
## Problem

The weekly policy assignment sync workflows (`update-alz.yml` and `update-amba.yml`) **fully regenerate** every policy assignment JSON from the upstream Enterprise-Scale / AMBA ARM templates — they do not patch existing files.

When an upstream template has no top-level `location` (e.g. `Enforce-ALDO-Services`), the sync script's fallback injected a **hardcoded `uksouth`** region. This:

1. Overwrote the library's curated `${default_location}` placeholder with a real region, and
2. Appended `location` **after** `properties` (because `Add-Member` only appends), instead of the curated position right after `name`.

This is what produced the unexpected change in #325, where `"location": "${default_location}"` was replaced with `"location": "uksouth"`.

## Fix

Replace the location fallback block in **both** copies of `Invoke-LibraryUpdatePolicyAssignmentArchetypes.ps1` (`platform/alz/scripts/` and `platform/amba/scripts/`):

- **Value** — emit the `${default_location}` placeholder instead of a hardcoded region. It remains a true fallback: any real upstream-supplied location is preserved.
- **Position** — rebuild the assignment as an `[ordered]` dictionary so `location` is positioned immediately after `name`, matching the curated convention (`type, apiVersion, name, location, dependsOn, …`).

## Impact on next sync

- **Zero diff churn** on the ~60 already-correct ALZ assignments and all AMBA assignments (value and position both already match).
- **Normalizes** the ~20 stale `uksouth` ALZ assignments back to `${default_location}` in the correct position.

> Note: the already-committed `uksouth` library JSON files are intentionally **not** modified in this PR — they self-correct on the next sync run. Regenerating them by hand risks EOL/whitespace diffs that wouldn't match CI-generated output.

## Validation

- Prototyped and tested both branches of the logic (location missing → placeholder; location present → preserved), and confirmed nested `properties` mutations still apply correctly after the object rebuild.
- Both edited scripts pass the PowerShell AST parser with no errors.
- Confirmed no remaining hardcoded `uksouth` location fallbacks anywhere in the repo.