### PR TITLE
Fix landing zones display name standardization

### DIFF
--- a/platform/alz/architecture_definitions/alz.alz_architecture_definition.json
+++ b/platform/alz/architecture_definitions/alz.alz_architecture_definition.json
@@ -24,7 +24,7 @@
       "archetypes": [
         "landing_zones"
       ],
-      "display_name": "Landing zones",
+      "display_name": "Landing Zones",
       "exists": false,
       "id": "landingzones",
       "parent_id": "alz"

--- a/platform/amba/architecture_definitions/amba.alz_architecture_definition.json
+++ b/platform/amba/architecture_definitions/amba.alz_architecture_definition.json
@@ -24,7 +24,7 @@
       "archetypes": [
         "amba_landing_zones"
       ],
-      "display_name": "Landing zones",
+      "display_name": "Landing Zones",
       "exists": true,
       "id": "landingzones",
       "parent_id": "alz"

--- a/platform/slz/architecture_definitions/slz.alz_architecture_definition.json
+++ b/platform/slz/architecture_definitions/slz.alz_architecture_definition.json
@@ -25,7 +25,7 @@
       "archetypes": [
         "landing_zones"
       ],
-      "display_name": "Landing zones",
+      "display_name": "Landing Zones",
       "exists": false,
       "id": "landingzones",
       "parent_id": "slz"


### PR DESCRIPTION
## Summary

Standardize the display name used for the landing zones management group.

Changes:
- Updated "Landing zones" to "Landing Zones"
- Applied consistently across ALZ, AMBA, and SLZ architecture definitions

Fixes Azure-Landing-Zones Issue [#289](https://github.com/Azure/Azure-Landing-Zones/issues/289)