### PR TITLE
feat(amba): add per-resource tag overrides for all tunable metric alerts

### DIFF
--- a/platform/amba/policy_definitions/Deploy-P2SVPNGateways-P2SBandwidth-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-P2SVPNGateways-P2SBandwidth-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.2.1-preview"
+      "version": "1.2.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-autoMitigate-Override_'), field('tags._amba-P2SBandwidth-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-enabled-Override_'), field('tags._amba-P2SBandwidth-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-evaluationFrequency-Override_'), field('tags._amba-P2SBandwidth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-severity-Override_'), field('tags._amba-P2SBandwidth-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-threshold-Override_'), field('tags._amba-P2SBandwidth-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-windowSize-Override_'), field('tags._amba-P2SBandwidth-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-enabled-Override_'), field('tags._amba-P2SBandwidth-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-evaluationFrequency-Override_'), field('tags._amba-P2SBandwidth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-windowSize-Override_'), field('tags._amba-P2SBandwidth-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-severity-Override_'), field('tags._amba-P2SBandwidth-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SBandwidth-autoMitigate-Override_'), field('tags._amba-P2SBandwidth-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-P2SVPNGateways-P2SConnectionCount-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-P2SVPNGateways-P2SConnectionCount-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-autoMitigate-Override_'), field('tags._amba-P2SConnectionCount-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-enabled-Override_'), field('tags._amba-P2SConnectionCount-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-evaluationFrequency-Override_'), field('tags._amba-P2SConnectionCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-severity-Override_'), field('tags._amba-P2SConnectionCount-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-threshold-Override_'), field('tags._amba-P2SConnectionCount-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-windowSize-Override_'), field('tags._amba-P2SConnectionCount-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-enabled-Override_'), field('tags._amba-P2SConnectionCount-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-evaluationFrequency-Override_'), field('tags._amba-P2SConnectionCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-windowSize-Override_'), field('tags._amba-P2SConnectionCount-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-severity-Override_'), field('tags._amba-P2SConnectionCount-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-P2SConnectionCount-autoMitigate-Override_'), field('tags._amba-P2SConnectionCount-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-P2SVPNGateways-UserVpnRouteCount-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-P2SVPNGateways-UserVpnRouteCount-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-autoMitigate-Override_'), field('tags._amba-UserVpnRouteCount-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-enabled-Override_'), field('tags._amba-UserVpnRouteCount-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-evaluationFrequency-Override_'), field('tags._amba-UserVpnRouteCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-severity-Override_'), field('tags._amba-UserVpnRouteCount-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-threshold-Override_'), field('tags._amba-UserVpnRouteCount-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-windowSize-Override_'), field('tags._amba-UserVpnRouteCount-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-enabled-Override_'), field('tags._amba-UserVpnRouteCount-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-evaluationFrequency-Override_'), field('tags._amba-UserVpnRouteCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-windowSize-Override_'), field('tags._amba-UserVpnRouteCount-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-severity-Override_'), field('tags._amba-UserVpnRouteCount-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UserVpnRouteCount-autoMitigate-Override_'), field('tags._amba-UserVpnRouteCount-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-VirtualHubs-BgpPeerStatus-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-VirtualHubs-BgpPeerStatus-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.2.1-preview"
+      "version": "1.2.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-autoMitigate-Override_'), field('tags._amba-bgppeerstatus-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-enabled-Override_'), field('tags._amba-bgppeerstatus-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-evaluationFrequency-Override_'), field('tags._amba-bgppeerstatus-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-severity-Override_'), field('tags._amba-bgppeerstatus-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-threshold-Override_'), field('tags._amba-bgppeerstatus-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-windowSize-Override_'), field('tags._amba-bgppeerstatus-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-enabled-Override_'), field('tags._amba-bgppeerstatus-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-evaluationFrequency-Override_'), field('tags._amba-bgppeerstatus-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-windowSize-Override_'), field('tags._amba-bgppeerstatus-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-severity-Override_'), field('tags._amba-bgppeerstatus-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-autoMitigate-Override_'), field('tags._amba-bgppeerstatus-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-VirtualHubs-CountOfRoutesAdvertisedToPeer-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-VirtualHubs-CountOfRoutesAdvertisedToPeer-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.2.1-preview"
+      "version": "1.2.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-autoMitigate-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-enabled-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-evaluationFrequency-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-severity-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-threshold-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-windowSize-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-enabled-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-evaluationFrequency-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-windowSize-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-severity-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesAdvertisedToPeer-autoMitigate-Override_'), field('tags._amba-CountOfRoutesAdvertisedToPeer-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-VirtualHubs-CountOfRoutesLearnedFromPeer-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-VirtualHubs-CountOfRoutesLearnedFromPeer-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-autoMitigate-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-enabled-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-evaluationFrequency-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-severity-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-threshold-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-windowSize-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-enabled-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-evaluationFrequency-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-windowSize-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-severity-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CountOfRoutesLearnedFromPeer-autoMitigate-Override_'), field('tags._amba-CountOfRoutesLearnedFromPeer-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-VirtualHubs-RoutingInfrastructureUnits-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-VirtualHubs-RoutingInfrastructureUnits-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-autoMitigate-Override_'), field('tags._amba-RoutingInfrastructureUnits-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-enabled-Override_'), field('tags._amba-RoutingInfrastructureUnits-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-evaluationFrequency-Override_'), field('tags._amba-RoutingInfrastructureUnits-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-severity-Override_'), field('tags._amba-RoutingInfrastructureUnits-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-threshold-Override_'), field('tags._amba-RoutingInfrastructureUnits-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-windowSize-Override_'), field('tags._amba-RoutingInfrastructureUnits-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-enabled-Override_'), field('tags._amba-RoutingInfrastructureUnits-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-evaluationFrequency-Override_'), field('tags._amba-RoutingInfrastructureUnits-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-windowSize-Override_'), field('tags._amba-RoutingInfrastructureUnits-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-severity-Override_'), field('tags._amba-RoutingInfrastructureUnits-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RoutingInfrastructureUnits-autoMitigate-Override_'), field('tags._amba-RoutingInfrastructureUnits-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-VirtualHubs-SpokeVMUtilization-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-VirtualHubs-SpokeVMUtilization-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-autoMitigate-Override_'), field('tags._amba-SpokeVMUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-enabled-Override_'), field('tags._amba-SpokeVMUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-evaluationFrequency-Override_'), field('tags._amba-SpokeVMUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-severity-Override_'), field('tags._amba-SpokeVMUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-threshold-Override_'), field('tags._amba-SpokeVMUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-windowSize-Override_'), field('tags._amba-SpokeVMUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-enabled-Override_'), field('tags._amba-SpokeVMUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-evaluationFrequency-Override_'), field('tags._amba-SpokeVMUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-windowSize-Override_'), field('tags._amba-SpokeVMUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-severity-Override_'), field('tags._amba-SpokeVMUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SpokeVMUtilization-autoMitigate-Override_'), field('tags._amba-SpokeVMUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy-VirtualHubs-VirtualHubDataProcessed-Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy-VirtualHubs-VirtualHubDataProcessed-Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-autoMitigate-Override_'), field('tags._amba-VirtualHubDataProcessed-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-enabled-Override_'), field('tags._amba-VirtualHubDataProcessed-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-evaluationFrequency-Override_'), field('tags._amba-VirtualHubDataProcessed-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-severity-Override_'), field('tags._amba-VirtualHubDataProcessed-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-threshold-Override_'), field('tags._amba-VirtualHubDataProcessed-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-windowSize-Override_'), field('tags._amba-VirtualHubDataProcessed-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-enabled-Override_'), field('tags._amba-VirtualHubDataProcessed-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-evaluationFrequency-Override_'), field('tags._amba-VirtualHubDataProcessed-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-windowSize-Override_'), field('tags._amba-VirtualHubDataProcessed-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-severity-Override_'), field('tags._amba-VirtualHubDataProcessed-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualHubDataProcessed-autoMitigate-Override_'), field('tags._amba-VirtualHubDataProcessed-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AA_TotalJob_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AA_TotalJob_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Automation",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-autoMitigate-Override_'), field('tags._amba-TotalJob-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-enabled-Override_'), field('tags._amba-TotalJob-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-evaluationFrequency-Override_'), field('tags._amba-TotalJob-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-severity-Override_'), field('tags._amba-TotalJob-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-threshold-Override_'), field('tags._amba-TotalJob-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-windowSize-Override_'), field('tags._amba-TotalJob-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -293,23 +293,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-enabled-Override_'), field('tags._amba-TotalJob-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-evaluationFrequency-Override_'), field('tags._amba-TotalJob-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-windowSize-Override_'), field('tags._amba-TotalJob-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-severity-Override_'), field('tags._amba-TotalJob-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TotalJob-autoMitigate-Override_'), field('tags._amba-TotalJob-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AFW_ApplicationRuleHit_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AFW_ApplicationRuleHit_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-autoMitigate-Override_'), field('tags._amba-ApplicationRuleHit-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-enabled-Override_'), field('tags._amba-ApplicationRuleHit-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-evaluationFrequency-Override_'), field('tags._amba-ApplicationRuleHit-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-severity-Override_'), field('tags._amba-ApplicationRuleHit-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-threshold-Override_'), field('tags._amba-ApplicationRuleHit-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-windowSize-Override_'), field('tags._amba-ApplicationRuleHit-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-enabled-Override_'), field('tags._amba-ApplicationRuleHit-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-evaluationFrequency-Override_'), field('tags._amba-ApplicationRuleHit-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-windowSize-Override_'), field('tags._amba-ApplicationRuleHit-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-severity-Override_'), field('tags._amba-ApplicationRuleHit-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationRuleHit-autoMitigate-Override_'), field('tags._amba-ApplicationRuleHit-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AFW_FirewallHealth_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AFW_FirewallHealth_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-autoMitigate-Override_'), field('tags._amba-FirewallHealth-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-enabled-Override_'), field('tags._amba-FirewallHealth-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-evaluationFrequency-Override_'), field('tags._amba-FirewallHealth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-severity-Override_'), field('tags._amba-FirewallHealth-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-threshold-Override_'), field('tags._amba-FirewallHealth-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-windowSize-Override_'), field('tags._amba-FirewallHealth-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-enabled-Override_'), field('tags._amba-FirewallHealth-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-evaluationFrequency-Override_'), field('tags._amba-FirewallHealth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-windowSize-Override_'), field('tags._amba-FirewallHealth-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-severity-Override_'), field('tags._amba-FirewallHealth-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FirewallHealth-autoMitigate-Override_'), field('tags._amba-FirewallHealth-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AFW_NetworkRuleHit_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AFW_NetworkRuleHit_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1-preview"
+      "version": "1.3.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-autoMitigate-Override_'), field('tags._amba-NetworkRuleHit-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-enabled-Override_'), field('tags._amba-NetworkRuleHit-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-evaluationFrequency-Override_'), field('tags._amba-NetworkRuleHit-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-severity-Override_'), field('tags._amba-NetworkRuleHit-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-threshold-Override_'), field('tags._amba-NetworkRuleHit-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-windowSize-Override_'), field('tags._amba-NetworkRuleHit-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-enabled-Override_'), field('tags._amba-NetworkRuleHit-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-evaluationFrequency-Override_'), field('tags._amba-NetworkRuleHit-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-windowSize-Override_'), field('tags._amba-NetworkRuleHit-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-severity-Override_'), field('tags._amba-NetworkRuleHit-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-NetworkRuleHit-autoMitigate-Override_'), field('tags._amba-NetworkRuleHit-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AFW_SNATPortUtilization_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AFW_SNATPortUtilization_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-autoMitigate-Override_'), field('tags._amba-SNATPortUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-enabled-Override_'), field('tags._amba-SNATPortUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-evaluationFrequency-Override_'), field('tags._amba-SNATPortUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-severity-Override_'), field('tags._amba-SNATPortUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-threshold-Override_'), field('tags._amba-SNATPortUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-windowSize-Override_'), field('tags._amba-SNATPortUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-enabled-Override_'), field('tags._amba-SNATPortUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-evaluationFrequency-Override_'), field('tags._amba-SNATPortUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-windowSize-Override_'), field('tags._amba-SNATPortUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-severity-Override_'), field('tags._amba-SNATPortUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SNATPortUtilization-autoMitigate-Override_'), field('tags._amba-SNATPortUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AG_ApplicationGatewayTotalTime_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_ApplicationGatewayTotalTime_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.5.1"
+      "version": "1.5.3"
     },
     "mode": "All",
     "parameters": {
@@ -173,22 +173,22 @@
               "mode": "incremental",
               "parameters": {
                 "alertSensitivity": {
-                  "value": "[parameters('alertSensitivity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-alertSensitivity-Override_'), field('tags._amba-ApplicationGatewayTotalTime-alertSensitivity-Override_'), parameters('alertSensitivity'))]"
                 },
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-autoMitigate-Override_'), field('tags._amba-ApplicationGatewayTotalTime-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-enabled-Override_'), field('tags._amba-ApplicationGatewayTotalTime-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-evaluationFrequency-Override_'), field('tags._amba-ApplicationGatewayTotalTime-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-evaluationPeriods-Override_'), field('tags._amba-ApplicationGatewayTotalTime-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-failingPeriods-Override_'), field('tags._amba-ApplicationGatewayTotalTime-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -197,10 +197,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-severity-Override_'), field('tags._amba-ApplicationGatewayTotalTime-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-windowSize-Override_'), field('tags._amba-ApplicationGatewayTotalTime-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -331,23 +331,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-enabled-Override_'), field('tags._amba-ApplicationGatewayTotalTime-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-evaluationFrequency-Override_'), field('tags._amba-ApplicationGatewayTotalTime-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-windowSize-Override_'), field('tags._amba-ApplicationGatewayTotalTime-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-severity-Override_'), field('tags._amba-ApplicationGatewayTotalTime-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-autoMitigate-Override_'), field('tags._amba-ApplicationGatewayTotalTime-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -359,15 +359,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "[parameters('alertSensitivity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-alertSensitivity-Override_'), field('tags._amba-ApplicationGatewayTotalTime-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-failingPeriods-Override_'), field('tags._amba-ApplicationGatewayTotalTime-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ApplicationGatewayTotalTime-evaluationPeriods-Override_'), field('tags._amba-ApplicationGatewayTotalTime-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_AG_BackendLastByteResponseTime_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_BackendLastByteResponseTime_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.5.1"
+      "version": "1.5.3"
     },
     "mode": "All",
     "parameters": {
@@ -173,22 +173,22 @@
               "mode": "incremental",
               "parameters": {
                 "alertSensitivity": {
-                  "value": "[parameters('alertSensitivity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-alertSensitivity-Override_'), field('tags._amba-BackendLastByteResponseTime-alertSensitivity-Override_'), parameters('alertSensitivity'))]"
                 },
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-autoMitigate-Override_'), field('tags._amba-BackendLastByteResponseTime-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-enabled-Override_'), field('tags._amba-BackendLastByteResponseTime-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-evaluationFrequency-Override_'), field('tags._amba-BackendLastByteResponseTime-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-evaluationPeriods-Override_'), field('tags._amba-BackendLastByteResponseTime-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-failingPeriods-Override_'), field('tags._amba-BackendLastByteResponseTime-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -197,10 +197,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-severity-Override_'), field('tags._amba-BackendLastByteResponseTime-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-windowSize-Override_'), field('tags._amba-BackendLastByteResponseTime-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -331,23 +331,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-enabled-Override_'), field('tags._amba-BackendLastByteResponseTime-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-evaluationFrequency-Override_'), field('tags._amba-BackendLastByteResponseTime-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-windowSize-Override_'), field('tags._amba-BackendLastByteResponseTime-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-severity-Override_'), field('tags._amba-BackendLastByteResponseTime-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-autoMitigate-Override_'), field('tags._amba-BackendLastByteResponseTime-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -359,15 +359,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "[parameters('alertSensitivity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-alertSensitivity-Override_'), field('tags._amba-BackendLastByteResponseTime-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-failingPeriods-Override_'), field('tags._amba-BackendLastByteResponseTime-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendLastByteResponseTime-evaluationPeriods-Override_'), field('tags._amba-BackendLastByteResponseTime-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_AG_CPUUtilization_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_CPUUtilization_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-autoMitigate-Override_'), field('tags._amba-CpuUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-enabled-Override_'), field('tags._amba-CpuUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-evaluationFrequency-Override_'), field('tags._amba-CpuUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-severity-Override_'), field('tags._amba-CpuUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-threshold-Override_'), field('tags._amba-CpuUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-windowSize-Override_'), field('tags._amba-CpuUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-enabled-Override_'), field('tags._amba-CpuUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-evaluationFrequency-Override_'), field('tags._amba-CpuUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-windowSize-Override_'), field('tags._amba-CpuUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-severity-Override_'), field('tags._amba-CpuUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuUtilization-autoMitigate-Override_'), field('tags._amba-CpuUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AG_CapacityUnits_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_CapacityUnits_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-autoMitigate-Override_'), field('tags._amba-CapacityUnits-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-enabled-Override_'), field('tags._amba-CapacityUnits-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-evaluationFrequency-Override_'), field('tags._amba-CapacityUnits-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-severity-Override_'), field('tags._amba-CapacityUnits-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-threshold-Override_'), field('tags._amba-CapacityUnits-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-windowSize-Override_'), field('tags._amba-CapacityUnits-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-enabled-Override_'), field('tags._amba-CapacityUnits-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-evaluationFrequency-Override_'), field('tags._amba-CapacityUnits-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-windowSize-Override_'), field('tags._amba-CapacityUnits-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-severity-Override_'), field('tags._amba-CapacityUnits-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CapacityUnits-autoMitigate-Override_'), field('tags._amba-CapacityUnits-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AG_ComputeUnits_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_ComputeUnits_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-autoMitigate-Override_'), field('tags._amba-ComputeUnits-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-enabled-Override_'), field('tags._amba-ComputeUnits-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-evaluationFrequency-Override_'), field('tags._amba-ComputeUnits-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-severity-Override_'), field('tags._amba-ComputeUnits-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-threshold-Override_'), field('tags._amba-ComputeUnits-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-windowSize-Override_'), field('tags._amba-ComputeUnits-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-enabled-Override_'), field('tags._amba-ComputeUnits-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-evaluationFrequency-Override_'), field('tags._amba-ComputeUnits-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-windowSize-Override_'), field('tags._amba-ComputeUnits-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-severity-Override_'), field('tags._amba-ComputeUnits-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ComputeUnits-autoMitigate-Override_'), field('tags._amba-ComputeUnits-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_AG_FailedRequests_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_FailedRequests_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -166,22 +166,22 @@
               "mode": "incremental",
               "parameters": {
                 "alertSensitivity": {
-                  "value": "[parameters('alertSensitivity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-alertSensitivity-Override_'), field('tags._amba-FailedRequests-alertSensitivity-Override_'), parameters('alertSensitivity'))]"
                 },
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-autoMitigate-Override_'), field('tags._amba-FailedRequests-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-enabled-Override_'), field('tags._amba-FailedRequests-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-evaluationFrequency-Override_'), field('tags._amba-FailedRequests-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-evaluationPeriods-Override_'), field('tags._amba-FailedRequests-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-failingPeriods-Override_'), field('tags._amba-FailedRequests-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -190,10 +190,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-severity-Override_'), field('tags._amba-FailedRequests-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-windowSize-Override_'), field('tags._amba-FailedRequests-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -324,23 +324,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-enabled-Override_'), field('tags._amba-FailedRequests-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-evaluationFrequency-Override_'), field('tags._amba-FailedRequests-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-windowSize-Override_'), field('tags._amba-FailedRequests-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-severity-Override_'), field('tags._amba-FailedRequests-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-autoMitigate-Override_'), field('tags._amba-FailedRequests-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -352,15 +352,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "[parameters('alertSensitivity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-alertSensitivity-Override_'), field('tags._amba-FailedRequests-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-failingPeriods-Override_'), field('tags._amba-FailedRequests-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-FailedRequests-evaluationPeriods-Override_'), field('tags._amba-FailedRequests-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_AG_ResponseStatus_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_ResponseStatus_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -166,22 +166,22 @@
               "mode": "incremental",
               "parameters": {
                 "alertSensitivity": {
-                  "value": "[parameters('alertSensitivity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-alertSensitivity-Override_'), field('tags._amba-ResponseStatus-alertSensitivity-Override_'), parameters('alertSensitivity'))]"
                 },
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-autoMitigate-Override_'), field('tags._amba-ResponseStatus-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-enabled-Override_'), field('tags._amba-ResponseStatus-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-evaluationFrequency-Override_'), field('tags._amba-ResponseStatus-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-evaluationPeriods-Override_'), field('tags._amba-ResponseStatus-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-failingPeriods-Override_'), field('tags._amba-ResponseStatus-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -190,10 +190,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-severity-Override_'), field('tags._amba-ResponseStatus-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-windowSize-Override_'), field('tags._amba-ResponseStatus-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -334,23 +334,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-enabled-Override_'), field('tags._amba-ResponseStatus-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-evaluationFrequency-Override_'), field('tags._amba-ResponseStatus-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-windowSize-Override_'), field('tags._amba-ResponseStatus-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-severity-Override_'), field('tags._amba-ResponseStatus-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-autoMitigate-Override_'), field('tags._amba-ResponseStatus-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -362,15 +362,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "[parameters('alertSensitivity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-alertSensitivity-Override_'), field('tags._amba-ResponseStatus-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-failingPeriods-Override_'), field('tags._amba-ResponseStatus-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ResponseStatus-evaluationPeriods-Override_'), field('tags._amba-ResponseStatus-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_AG_UnhealthyHostCount_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_AG_UnhealthyHostCount_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-autoMitigate-Override_'), field('tags._amba-UnhealthyHostCount-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-enabled-Override_'), field('tags._amba-UnhealthyHostCount-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-evaluationFrequency-Override_'), field('tags._amba-UnhealthyHostCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-severity-Override_'), field('tags._amba-UnhealthyHostCount-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-threshold-Override_'), field('tags._amba-UnhealthyHostCount-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-windowSize-Override_'), field('tags._amba-UnhealthyHostCount-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-enabled-Override_'), field('tags._amba-UnhealthyHostCount-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-evaluationFrequency-Override_'), field('tags._amba-UnhealthyHostCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-windowSize-Override_'), field('tags._amba-UnhealthyHostCount-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-severity-Override_'), field('tags._amba-UnhealthyHostCount-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UnhealthyHostCount-autoMitigate-Override_'), field('tags._amba-UnhealthyHostCount-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ALB_DataPathAvailability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ALB_DataPathAvailability_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-autoMitigate-Override_'), field('tags._amba-VipAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-enabled-Override_'), field('tags._amba-VipAvailability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-evaluationFrequency-Override_'), field('tags._amba-VipAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-severity-Override_'), field('tags._amba-VipAvailability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-threshold-Override_'), field('tags._amba-VipAvailability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-windowSize-Override_'), field('tags._amba-VipAvailability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-enabled-Override_'), field('tags._amba-VipAvailability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-evaluationFrequency-Override_'), field('tags._amba-VipAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-windowSize-Override_'), field('tags._amba-VipAvailability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-severity-Override_'), field('tags._amba-VipAvailability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-autoMitigate-Override_'), field('tags._amba-VipAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ALB_GlobalBackendAvailability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ALB_GlobalBackendAvailability_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -149,13 +149,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-autoMitigate-Override_'), field('tags._amba-GlobalBackendAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-enabled-Override_'), field('tags._amba-GlobalBackendAvailability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-evaluationFrequency-Override_'), field('tags._amba-GlobalBackendAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -164,13 +164,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-severity-Override_'), field('tags._amba-GlobalBackendAvailability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-threshold-Override_'), field('tags._amba-GlobalBackendAvailability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-windowSize-Override_'), field('tags._amba-GlobalBackendAvailability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -285,23 +285,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-enabled-Override_'), field('tags._amba-GlobalBackendAvailability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-evaluationFrequency-Override_'), field('tags._amba-GlobalBackendAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-windowSize-Override_'), field('tags._amba-GlobalBackendAvailability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-severity-Override_'), field('tags._amba-GlobalBackendAvailability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-GlobalBackendAvailability-autoMitigate-Override_'), field('tags._amba-GlobalBackendAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ALB_HealthProbeStatus_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ALB_HealthProbeStatus_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -156,13 +156,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-autoMitigate-Override_'), field('tags._amba-DipAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-enabled-Override_'), field('tags._amba-DipAvailability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-evaluationFrequency-Override_'), field('tags._amba-DipAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -171,13 +171,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-severity-Override_'), field('tags._amba-DipAvailability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-threshold-Override_'), field('tags._amba-DipAvailability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-windowSize-Override_'), field('tags._amba-DipAvailability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -292,23 +292,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-enabled-Override_'), field('tags._amba-DipAvailability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-evaluationFrequency-Override_'), field('tags._amba-DipAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-windowSize-Override_'), field('tags._amba-DipAvailability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-severity-Override_'), field('tags._amba-DipAvailability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DipAvailability-autoMitigate-Override_'), field('tags._amba-DipAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ALB_UsedSNATPorts_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ALB_UsedSNATPorts_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-autoMitigate-Override_'), field('tags._amba-UsedSNATPorts-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-enabled-Override_'), field('tags._amba-UsedSNATPorts-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-evaluationFrequency-Override_'), field('tags._amba-UsedSNATPorts-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-severity-Override_'), field('tags._amba-UsedSNATPorts-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-threshold-Override_'), field('tags._amba-UsedSNATPorts-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-windowSize-Override_'), field('tags._amba-UsedSNATPorts-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-enabled-Override_'), field('tags._amba-UsedSNATPorts-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-evaluationFrequency-Override_'), field('tags._amba-UsedSNATPorts-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-windowSize-Override_'), field('tags._amba-UsedSNATPorts-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-severity-Override_'), field('tags._amba-UsedSNATPorts-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-UsedSNATPorts-autoMitigate-Override_'), field('tags._amba-UsedSNATPorts-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_DNSZ_RegistrationCapacityUtil_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_DNSZ_RegistrationCapacityUtil_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-autoMitigate-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-enabled-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-evaluationFrequency-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-severity-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-threshold-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-windowSize-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-enabled-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-evaluationFrequency-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-windowSize-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-severity-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkWithRegistrationCapacityUtilization-autoMitigate-Override_'), field('tags._amba-VirtualNetworkWithRegistrationCapacityUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERCIR_ArpAvailability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERCIR_ArpAvailability_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-autoMitigate-Override_'), field('tags._amba-ArpAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-enabled-Override_'), field('tags._amba-ArpAvailability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-evaluationFrequency-Override_'), field('tags._amba-ArpAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-severity-Override_'), field('tags._amba-ArpAvailability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-threshold-Override_'), field('tags._amba-ArpAvailability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-windowSize-Override_'), field('tags._amba-ArpAvailability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-enabled-Override_'), field('tags._amba-ArpAvailability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-evaluationFrequency-Override_'), field('tags._amba-ArpAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-windowSize-Override_'), field('tags._amba-ArpAvailability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-severity-Override_'), field('tags._amba-ArpAvailability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ArpAvailability-autoMitigate-Override_'), field('tags._amba-ArpAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERCIR_BgpAvailability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERCIR_BgpAvailability_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-autoMitigate-Override_'), field('tags._amba-BgpAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-enabled-Override_'), field('tags._amba-BgpAvailability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-evaluationFrequency-Override_'), field('tags._amba-BgpAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-severity-Override_'), field('tags._amba-BgpAvailability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-threshold-Override_'), field('tags._amba-BgpAvailability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-windowSize-Override_'), field('tags._amba-BgpAvailability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-enabled-Override_'), field('tags._amba-BgpAvailability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-evaluationFrequency-Override_'), field('tags._amba-BgpAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-windowSize-Override_'), field('tags._amba-BgpAvailability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-severity-Override_'), field('tags._amba-BgpAvailability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BgpAvailability-autoMitigate-Override_'), field('tags._amba-BgpAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERCIR_QosDropBitsInPerSecond_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERCIR_QosDropBitsInPerSecond_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-autoMitigate-Override_'), field('tags._amba-QosDropBitsInPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-enabled-Override_'), field('tags._amba-QosDropBitsInPerSecond-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-evaluationFrequency-Override_'), field('tags._amba-QosDropBitsInPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-evaluationPeriods-Override_'), field('tags._amba-QosDropBitsInPerSecond-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-failingPeriods-Override_'), field('tags._amba-QosDropBitsInPerSecond-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-severity-Override_'), field('tags._amba-QosDropBitsInPerSecond-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-windowSize-Override_'), field('tags._amba-QosDropBitsInPerSecond-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-enabled-Override_'), field('tags._amba-QosDropBitsInPerSecond-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-evaluationFrequency-Override_'), field('tags._amba-QosDropBitsInPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-windowSize-Override_'), field('tags._amba-QosDropBitsInPerSecond-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-severity-Override_'), field('tags._amba-QosDropBitsInPerSecond-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-autoMitigate-Override_'), field('tags._amba-QosDropBitsInPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-alertSensitivity-Override_'), field('tags._amba-QosDropBitsInPerSecond-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-failingPeriods-Override_'), field('tags._amba-QosDropBitsInPerSecond-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsInPerSecond-evaluationPeriods-Override_'), field('tags._amba-QosDropBitsInPerSecond-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_ERCIR_QosDropBitsOutPerSecond_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERCIR_QosDropBitsOutPerSecond_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-autoMitigate-Override_'), field('tags._amba-QosDropBitsOutPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-enabled-Override_'), field('tags._amba-QosDropBitsOutPerSecond-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-evaluationFrequency-Override_'), field('tags._amba-QosDropBitsOutPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-evaluationPeriods-Override_'), field('tags._amba-QosDropBitsOutPerSecond-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-failingPeriods-Override_'), field('tags._amba-QosDropBitsOutPerSecond-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-severity-Override_'), field('tags._amba-QosDropBitsOutPerSecond-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-windowSize-Override_'), field('tags._amba-QosDropBitsOutPerSecond-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-enabled-Override_'), field('tags._amba-QosDropBitsOutPerSecond-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-evaluationFrequency-Override_'), field('tags._amba-QosDropBitsOutPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-windowSize-Override_'), field('tags._amba-QosDropBitsOutPerSecond-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-severity-Override_'), field('tags._amba-QosDropBitsOutPerSecond-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-autoMitigate-Override_'), field('tags._amba-QosDropBitsOutPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-alertSensitivity-Override_'), field('tags._amba-QosDropBitsOutPerSecond-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-failingPeriods-Override_'), field('tags._amba-QosDropBitsOutPerSecond-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QosDropBitsOutPerSecond-evaluationPeriods-Override_'), field('tags._amba-QosDropBitsOutPerSecond-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteBitsIn_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteBitsIn_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-autoMitigate-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-enabled-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-evaluationFrequency-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-severity-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-threshold-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-windowSize-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-enabled-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-evaluationFrequency-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-windowSize-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-severity-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsInPerSecond-autoMitigate-Override_'), field('tags._amba-ERGatewayConnectionBitsInPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteBitsOut_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteBitsOut_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-autoMitigate-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-enabled-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-evaluationFrequency-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-severity-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-threshold-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-windowSize-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-enabled-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-evaluationFrequency-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-windowSize-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-severity-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ERGatewayConnectionBitsOutPerSecond-autoMitigate-Override_'), field('tags._amba-ERGatewayConnectionBitsOutPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteCpuUtil_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteCpuUtil_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-threshold-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteGatewayActiveFlows_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERGw_ExpressRouteGatewayActiveFlows_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.2.1-preview"
+      "version": "1.2.2-preview"
     },
     "mode": "All",
     "parameters": {
@@ -146,13 +146,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-enabled-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -161,13 +161,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-severity-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-threshold-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -282,23 +282,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-enabled-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-severity-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayActiveFlows-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayActiveFlows-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutLineProtocol_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutLineProtocol_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-autoMitigate-Override_'), field('tags._amba-LineProtocol-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-enabled-Override_'), field('tags._amba-LineProtocol-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-evaluationFrequency-Override_'), field('tags._amba-LineProtocol-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-severity-Override_'), field('tags._amba-LineProtocol-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-threshold-Override_'), field('tags._amba-LineProtocol-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-windowSize-Override_'), field('tags._amba-LineProtocol-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-enabled-Override_'), field('tags._amba-LineProtocol-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-evaluationFrequency-Override_'), field('tags._amba-LineProtocol-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-windowSize-Override_'), field('tags._amba-LineProtocol-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-severity-Override_'), field('tags._amba-LineProtocol-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-LineProtocol-autoMitigate-Override_'), field('tags._amba-LineProtocol-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutRxLightLevel_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutRxLightLevel_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-autoMitigate-Override_'), field('tags._amba-RxLightLevel-High-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-enabled-Override_'), field('tags._amba-RxLightLevel-High-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-evaluationFrequency-Override_'), field('tags._amba-RxLightLevel-High-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-severity-Override_'), field('tags._amba-RxLightLevel-High-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-threshold-Override_'), field('tags._amba-RxLightLevel-High-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-windowSize-Override_'), field('tags._amba-RxLightLevel-High-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -285,23 +285,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-enabled-Override_'), field('tags._amba-RxLightLevel-High-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-evaluationFrequency-Override_'), field('tags._amba-RxLightLevel-High-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-windowSize-Override_'), field('tags._amba-RxLightLevel-High-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-severity-Override_'), field('tags._amba-RxLightLevel-High-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-High-autoMitigate-Override_'), field('tags._amba-RxLightLevel-High-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutRxLightLevellow_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutRxLightLevellow_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-autoMitigate-Override_'), field('tags._amba-RxLightLevel-Low-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-enabled-Override_'), field('tags._amba-RxLightLevel-Low-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-evaluationFrequency-Override_'), field('tags._amba-RxLightLevel-Low-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-severity-Override_'), field('tags._amba-RxLightLevel-Low-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-threshold-Override_'), field('tags._amba-RxLightLevel-Low-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-windowSize-Override_'), field('tags._amba-RxLightLevel-Low-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -285,23 +285,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-enabled-Override_'), field('tags._amba-RxLightLevel-Low-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-evaluationFrequency-Override_'), field('tags._amba-RxLightLevel-Low-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-windowSize-Override_'), field('tags._amba-RxLightLevel-Low-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-severity-Override_'), field('tags._amba-RxLightLevel-Low-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RxLightLevel-Low-autoMitigate-Override_'), field('tags._amba-RxLightLevel-Low-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutTxLightLevell_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutTxLightLevell_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-autoMitigate-Override_'), field('tags._amba-TxLightLevel-High-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-enabled-Override_'), field('tags._amba-TxLightLevel-High-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-evaluationFrequency-Override_'), field('tags._amba-TxLightLevel-High-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-severity-Override_'), field('tags._amba-TxLightLevel-High-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-threshold-Override_'), field('tags._amba-TxLightLevel-High-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-windowSize-Override_'), field('tags._amba-TxLightLevel-High-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -285,23 +285,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-enabled-Override_'), field('tags._amba-TxLightLevel-High-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-evaluationFrequency-Override_'), field('tags._amba-TxLightLevel-High-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-windowSize-Override_'), field('tags._amba-TxLightLevel-High-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-severity-Override_'), field('tags._amba-TxLightLevel-High-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-High-autoMitigate-Override_'), field('tags._amba-TxLightLevel-High-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutTxLightLevellow_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERP_ExpressRoutTxLightLevellow_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-autoMitigate-Override_'), field('tags._amba-TxLightLevel-Low-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-enabled-Override_'), field('tags._amba-TxLightLevel-Low-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-evaluationFrequency-Override_'), field('tags._amba-TxLightLevel-Low-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-severity-Override_'), field('tags._amba-TxLightLevel-Low-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-threshold-Override_'), field('tags._amba-TxLightLevel-Low-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-windowSize-Override_'), field('tags._amba-TxLightLevel-Low-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -285,23 +285,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-enabled-Override_'), field('tags._amba-TxLightLevel-Low-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-evaluationFrequency-Override_'), field('tags._amba-TxLightLevel-Low-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-windowSize-Override_'), field('tags._amba-TxLightLevel-Low-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-severity-Override_'), field('tags._amba-TxLightLevel-Low-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TxLightLevel-Low-autoMitigate-Override_'), field('tags._amba-TxLightLevel-Low-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERP_ExpressRouteBitsIn_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERP_ExpressRouteBitsIn_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-autoMitigate-Override_'), field('tags._amba-PortBitsInPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-enabled-Override_'), field('tags._amba-PortBitsInPerSecond-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-evaluationFrequency-Override_'), field('tags._amba-PortBitsInPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-severity-Override_'), field('tags._amba-PortBitsInPerSecond-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-threshold-Override_'), field('tags._amba-PortBitsInPerSecond-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-windowSize-Override_'), field('tags._amba-PortBitsInPerSecond-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-enabled-Override_'), field('tags._amba-PortBitsInPerSecond-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-evaluationFrequency-Override_'), field('tags._amba-PortBitsInPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-windowSize-Override_'), field('tags._amba-PortBitsInPerSecond-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-severity-Override_'), field('tags._amba-PortBitsInPerSecond-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsInPerSecond-autoMitigate-Override_'), field('tags._amba-PortBitsInPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ERP_ExpressRouteBitsOut_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ERP_ExpressRouteBitsOut_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-autoMitigate-Override_'), field('tags._amba-PortBitsOutPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-enabled-Override_'), field('tags._amba-PortBitsOutPerSecond-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-evaluationFrequency-Override_'), field('tags._amba-PortBitsOutPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-severity-Override_'), field('tags._amba-PortBitsOutPerSecond-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-threshold-Override_'), field('tags._amba-PortBitsOutPerSecond-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-windowSize-Override_'), field('tags._amba-PortBitsOutPerSecond-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-enabled-Override_'), field('tags._amba-PortBitsOutPerSecond-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-evaluationFrequency-Override_'), field('tags._amba-PortBitsOutPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-windowSize-Override_'), field('tags._amba-PortBitsOutPerSecond-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-severity-Override_'), field('tags._amba-PortBitsOutPerSecond-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PortBitsOutPerSecond-autoMitigate-Override_'), field('tags._amba-PortBitsOutPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_FD_BackendHealth_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_FD_BackendHealth_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-autoMitigate-Override_'), field('tags._amba-BackendHealthPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-enabled-Override_'), field('tags._amba-BackendHealthPercentage-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-evaluationFrequency-Override_'), field('tags._amba-BackendHealthPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-severity-Override_'), field('tags._amba-BackendHealthPercentage-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-threshold-Override_'), field('tags._amba-BackendHealthPercentage-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-windowSize-Override_'), field('tags._amba-BackendHealthPercentage-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-enabled-Override_'), field('tags._amba-BackendHealthPercentage-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-evaluationFrequency-Override_'), field('tags._amba-BackendHealthPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-windowSize-Override_'), field('tags._amba-BackendHealthPercentage-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-severity-Override_'), field('tags._amba-BackendHealthPercentage-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendHealthPercentage-autoMitigate-Override_'), field('tags._amba-BackendHealthPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_FD_BackendRequestLatency_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_FD_BackendRequestLatency_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1"
+      "version": "1.3.3"
     },
     "mode": "All",
     "parameters": {
@@ -140,13 +140,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-autoMitigate-Override_'), field('tags._amba-BackendRequestLatency-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-enabled-Override_'), field('tags._amba-BackendRequestLatency-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-evaluationFrequency-Override_'), field('tags._amba-BackendRequestLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -155,10 +155,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-severity-Override_'), field('tags._amba-BackendRequestLatency-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-windowSize-Override_'), field('tags._amba-BackendRequestLatency-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -271,23 +271,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-enabled-Override_'), field('tags._amba-BackendRequestLatency-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-evaluationFrequency-Override_'), field('tags._amba-BackendRequestLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-windowSize-Override_'), field('tags._amba-BackendRequestLatency-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-severity-Override_'), field('tags._amba-BackendRequestLatency-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-autoMitigate-Override_'), field('tags._amba-BackendRequestLatency-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -299,15 +299,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-alertSensitivity-Override_'), field('tags._amba-BackendRequestLatency-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": 2,
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-failingPeriods-Override_'), field('tags._amba-BackendRequestLatency-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": 2,
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-BackendRequestLatency-evaluationPeriods-Override_'), field('tags._amba-BackendRequestLatency-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_FrontDoorCDN_OriginHealthPercentage_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_FrontDoorCDN_OriginHealthPercentage_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-autoMitigate-Override_'), field('tags._amba-OriginHealthPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-enabled-Override_'), field('tags._amba-OriginHealthPercentage-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-evaluationFrequency-Override_'), field('tags._amba-OriginHealthPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-severity-Override_'), field('tags._amba-OriginHealthPercentage-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-threshold-Override_'), field('tags._amba-OriginHealthPercentage-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-windowSize-Override_'), field('tags._amba-OriginHealthPercentage-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-enabled-Override_'), field('tags._amba-OriginHealthPercentage-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-evaluationFrequency-Override_'), field('tags._amba-OriginHealthPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-windowSize-Override_'), field('tags._amba-OriginHealthPercentage-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-severity-Override_'), field('tags._amba-OriginHealthPercentage-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginHealthPercentage-autoMitigate-Override_'), field('tags._amba-OriginHealthPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_FrontDoorCDN_OriginLatency_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_FrontDoorCDN_OriginLatency_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-autoMitigate-Override_'), field('tags._amba-OriginLatency-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-enabled-Override_'), field('tags._amba-OriginLatency-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-evaluationFrequency-Override_'), field('tags._amba-OriginLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-evaluationPeriods-Override_'), field('tags._amba-OriginLatency-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-failingPeriods-Override_'), field('tags._amba-OriginLatency-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-severity-Override_'), field('tags._amba-OriginLatency-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-windowSize-Override_'), field('tags._amba-OriginLatency-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-enabled-Override_'), field('tags._amba-OriginLatency-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-evaluationFrequency-Override_'), field('tags._amba-OriginLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-windowSize-Override_'), field('tags._amba-OriginLatency-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-severity-Override_'), field('tags._amba-OriginLatency-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-autoMitigate-Override_'), field('tags._amba-OriginLatency-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-alertSensitivity-Override_'), field('tags._amba-OriginLatency-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-failingPeriods-Override_'), field('tags._amba-OriginLatency-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-OriginLatency-evaluationPeriods-Override_'), field('tags._amba-OriginLatency-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_FrontDoorCDN_Percentage4XX_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_FrontDoorCDN_Percentage4XX_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-autoMitigate-Override_'), field('tags._amba-Percentage4XX-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-enabled-Override_'), field('tags._amba-Percentage4XX-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-evaluationFrequency-Override_'), field('tags._amba-Percentage4XX-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-evaluationPeriods-Override_'), field('tags._amba-Percentage4XX-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-failingPeriods-Override_'), field('tags._amba-Percentage4XX-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-severity-Override_'), field('tags._amba-Percentage4XX-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-windowSize-Override_'), field('tags._amba-Percentage4XX-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-enabled-Override_'), field('tags._amba-Percentage4XX-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-evaluationFrequency-Override_'), field('tags._amba-Percentage4XX-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-windowSize-Override_'), field('tags._amba-Percentage4XX-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-severity-Override_'), field('tags._amba-Percentage4XX-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-autoMitigate-Override_'), field('tags._amba-Percentage4XX-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-alertSensitivity-Override_'), field('tags._amba-Percentage4XX-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-failingPeriods-Override_'), field('tags._amba-Percentage4XX-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage4XX-evaluationPeriods-Override_'), field('tags._amba-Percentage4XX-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_FrontDoorCDN_Percentage5XX_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_FrontDoorCDN_Percentage5XX_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-autoMitigate-Override_'), field('tags._amba-Percentage5XX-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-enabled-Override_'), field('tags._amba-Percentage5XX-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-evaluationFrequency-Override_'), field('tags._amba-Percentage5XX-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-evaluationPeriods-Override_'), field('tags._amba-Percentage5XX-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-failingPeriods-Override_'), field('tags._amba-Percentage5XX-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-severity-Override_'), field('tags._amba-Percentage5XX-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-windowSize-Override_'), field('tags._amba-Percentage5XX-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-enabled-Override_'), field('tags._amba-Percentage5XX-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-evaluationFrequency-Override_'), field('tags._amba-Percentage5XX-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-windowSize-Override_'), field('tags._amba-Percentage5XX-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-severity-Override_'), field('tags._amba-Percentage5XX-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-autoMitigate-Override_'), field('tags._amba-Percentage5XX-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-alertSensitivity-Override_'), field('tags._amba-Percentage5XX-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-failingPeriods-Override_'), field('tags._amba-Percentage5XX-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Percentage5XX-evaluationPeriods-Override_'), field('tags._amba-Percentage5XX-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_KeyVault_Availability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_KeyVault_Availability_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Key Vault",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-autoMitigate-Override_'), field('tags._amba-Availability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-enabled-Override_'), field('tags._amba-Availability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-evaluationFrequency-Override_'), field('tags._amba-Availability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-severity-Override_'), field('tags._amba-Availability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-threshold-Override_'), field('tags._amba-Availability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-windowSize-Override_'), field('tags._amba-Availability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-enabled-Override_'), field('tags._amba-Availability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-evaluationFrequency-Override_'), field('tags._amba-Availability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-windowSize-Override_'), field('tags._amba-Availability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-severity-Override_'), field('tags._amba-Availability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-autoMitigate-Override_'), field('tags._amba-Availability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_KeyVault_Capacity_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_KeyVault_Capacity_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Key Vault",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-autoMitigate-Override_'), field('tags._amba-SaturationShoebox-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-enabled-Override_'), field('tags._amba-SaturationShoebox-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-evaluationFrequency-Override_'), field('tags._amba-SaturationShoebox-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-severity-Override_'), field('tags._amba-SaturationShoebox-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-threshold-Override_'), field('tags._amba-SaturationShoebox-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-windowSize-Override_'), field('tags._amba-SaturationShoebox-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-enabled-Override_'), field('tags._amba-SaturationShoebox-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-evaluationFrequency-Override_'), field('tags._amba-SaturationShoebox-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-windowSize-Override_'), field('tags._amba-SaturationShoebox-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-severity-Override_'), field('tags._amba-SaturationShoebox-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-SaturationShoebox-autoMitigate-Override_'), field('tags._amba-SaturationShoebox-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_KeyVault_Latency_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_KeyVault_Latency_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Key Vault",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-autoMitigate-Override_'), field('tags._amba-ServiceApiLatency-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-enabled-Override_'), field('tags._amba-ServiceApiLatency-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-evaluationFrequency-Override_'), field('tags._amba-ServiceApiLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-severity-Override_'), field('tags._amba-ServiceApiLatency-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-threshold-Override_'), field('tags._amba-ServiceApiLatency-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-windowSize-Override_'), field('tags._amba-ServiceApiLatency-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-enabled-Override_'), field('tags._amba-ServiceApiLatency-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-evaluationFrequency-Override_'), field('tags._amba-ServiceApiLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-windowSize-Override_'), field('tags._amba-ServiceApiLatency-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-severity-Override_'), field('tags._amba-ServiceApiLatency-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-autoMitigate-Override_'), field('tags._amba-ServiceApiLatency-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_KeyVault_Requests_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_KeyVault_Requests_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Key Vault",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -140,13 +140,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-autoMitigate-Override_'), field('tags._amba-ServiceApiResult-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-enabled-Override_'), field('tags._amba-ServiceApiResult-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-evaluationFrequency-Override_'), field('tags._amba-ServiceApiResult-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -155,10 +155,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-severity-Override_'), field('tags._amba-ServiceApiResult-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-windowSize-Override_'), field('tags._amba-ServiceApiResult-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -271,23 +271,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-enabled-Override_'), field('tags._amba-ServiceApiResult-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-evaluationFrequency-Override_'), field('tags._amba-ServiceApiResult-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-windowSize-Override_'), field('tags._amba-ServiceApiResult-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-severity-Override_'), field('tags._amba-ServiceApiResult-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-autoMitigate-Override_'), field('tags._amba-ServiceApiResult-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -299,15 +299,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-alertSensitivity-Override_'), field('tags._amba-ServiceApiResult-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": 4,
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-failingPeriods-Override_'), field('tags._amba-ServiceApiResult-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": 4,
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiResult-evaluationPeriods-Override_'), field('tags._amba-ServiceApiResult-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_ManagedHSMs_Availability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ManagedHSMs_Availability_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Key Vault",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-autoMitigate-Override_'), field('tags._amba-Availability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-enabled-Override_'), field('tags._amba-Availability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-evaluationFrequency-Override_'), field('tags._amba-Availability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-severity-Override_'), field('tags._amba-Availability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-threshold-Override_'), field('tags._amba-Availability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-windowSize-Override_'), field('tags._amba-Availability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-enabled-Override_'), field('tags._amba-Availability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-evaluationFrequency-Override_'), field('tags._amba-Availability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-windowSize-Override_'), field('tags._amba-Availability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-severity-Override_'), field('tags._amba-Availability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-autoMitigate-Override_'), field('tags._amba-Availability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_ManagedHSMs_Latency_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_ManagedHSMs_Latency_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Key Vault",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-autoMitigate-Override_'), field('tags._amba-ServiceApiLatency-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-enabled-Override_'), field('tags._amba-ServiceApiLatency-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-evaluationFrequency-Override_'), field('tags._amba-ServiceApiLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-severity-Override_'), field('tags._amba-ServiceApiLatency-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-threshold-Override_'), field('tags._amba-ServiceApiLatency-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-windowSize-Override_'), field('tags._amba-ServiceApiLatency-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-enabled-Override_'), field('tags._amba-ServiceApiLatency-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-evaluationFrequency-Override_'), field('tags._amba-ServiceApiLatency-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-windowSize-Override_'), field('tags._amba-ServiceApiLatency-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-severity-Override_'), field('tags._amba-ServiceApiLatency-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ServiceApiLatency-autoMitigate-Override_'), field('tags._amba-ServiceApiLatency-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_PDNSZ_CapacityUtil_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_PDNSZ_CapacityUtil_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-autoMitigate-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-enabled-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-evaluationFrequency-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-severity-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-threshold-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-windowSize-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-enabled-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-evaluationFrequency-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-windowSize-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-severity-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VirtualNetworkLinkCapacityUtilization-autoMitigate-Override_'), field('tags._amba-VirtualNetworkLinkCapacityUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_PDNSZ_QueryVolume_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_PDNSZ_QueryVolume_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-autoMitigate-Override_'), field('tags._amba-QueryVolume-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-enabled-Override_'), field('tags._amba-QueryVolume-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-evaluationFrequency-Override_'), field('tags._amba-QueryVolume-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-severity-Override_'), field('tags._amba-QueryVolume-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-threshold-Override_'), field('tags._amba-QueryVolume-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-windowSize-Override_'), field('tags._amba-QueryVolume-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-enabled-Override_'), field('tags._amba-QueryVolume-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-evaluationFrequency-Override_'), field('tags._amba-QueryVolume-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-windowSize-Override_'), field('tags._amba-QueryVolume-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-severity-Override_'), field('tags._amba-QueryVolume-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-QueryVolume-autoMitigate-Override_'), field('tags._amba-QueryVolume-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_PDNSZ_RecordSetCapacity_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_PDNSZ_RecordSetCapacity_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-autoMitigate-Override_'), field('tags._amba-RecordSetCapacityUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-enabled-Override_'), field('tags._amba-RecordSetCapacityUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-evaluationFrequency-Override_'), field('tags._amba-RecordSetCapacityUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-severity-Override_'), field('tags._amba-RecordSetCapacityUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-threshold-Override_'), field('tags._amba-RecordSetCapacityUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-windowSize-Override_'), field('tags._amba-RecordSetCapacityUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-enabled-Override_'), field('tags._amba-RecordSetCapacityUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-evaluationFrequency-Override_'), field('tags._amba-RecordSetCapacityUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-windowSize-Override_'), field('tags._amba-RecordSetCapacityUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-severity-Override_'), field('tags._amba-RecordSetCapacityUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-RecordSetCapacityUtilization-autoMitigate-Override_'), field('tags._amba-RecordSetCapacityUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_PublicIp_BytesInDDoSAttack_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_PublicIp_BytesInDDoSAttack_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-autoMitigate-Override_'), field('tags._amba-bytesinddos-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-enabled-Override_'), field('tags._amba-bytesinddos-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-evaluationFrequency-Override_'), field('tags._amba-bytesinddos-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-severity-Override_'), field('tags._amba-bytesinddos-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-threshold-Override_'), field('tags._amba-bytesinddos-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-windowSize-Override_'), field('tags._amba-bytesinddos-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-enabled-Override_'), field('tags._amba-bytesinddos-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-evaluationFrequency-Override_'), field('tags._amba-bytesinddos-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-windowSize-Override_'), field('tags._amba-bytesinddos-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-severity-Override_'), field('tags._amba-bytesinddos-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bytesinddos-autoMitigate-Override_'), field('tags._amba-bytesinddos-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_PublicIp_DDoSAttack_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_PublicIp_DDoSAttack_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-autoMitigate-Override_'), field('tags._amba-ifunderddosattack-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-enabled-Override_'), field('tags._amba-ifunderddosattack-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-evaluationFrequency-Override_'), field('tags._amba-ifunderddosattack-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-severity-Override_'), field('tags._amba-ifunderddosattack-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-threshold-Override_'), field('tags._amba-ifunderddosattack-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-windowSize-Override_'), field('tags._amba-ifunderddosattack-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-enabled-Override_'), field('tags._amba-ifunderddosattack-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-evaluationFrequency-Override_'), field('tags._amba-ifunderddosattack-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-windowSize-Override_'), field('tags._amba-ifunderddosattack-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-severity-Override_'), field('tags._amba-ifunderddosattack-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-autoMitigate-Override_'), field('tags._amba-ifunderddosattack-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_PublicIp_PacketsInDDoSAttack_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-autoMitigate-Override_'), field('tags._amba-PacketsInDDoS-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-enabled-Override_'), field('tags._amba-PacketsInDDoS-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-evaluationFrequency-Override_'), field('tags._amba-PacketsInDDoS-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-severity-Override_'), field('tags._amba-PacketsInDDoS-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-threshold-Override_'), field('tags._amba-PacketsInDDoS-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-windowSize-Override_'), field('tags._amba-PacketsInDDoS-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-enabled-Override_'), field('tags._amba-PacketsInDDoS-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-evaluationFrequency-Override_'), field('tags._amba-PacketsInDDoS-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-windowSize-Override_'), field('tags._amba-PacketsInDDoS-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-severity-Override_'), field('tags._amba-PacketsInDDoS-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-PacketsInDDoS-autoMitigate-Override_'), field('tags._amba-PacketsInDDoS-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_PublicIp_VIPAvailability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_PublicIp_VIPAvailability_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-autoMitigate-Override_'), field('tags._amba-VipAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-enabled-Override_'), field('tags._amba-VipAvailability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-evaluationFrequency-Override_'), field('tags._amba-VipAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-severity-Override_'), field('tags._amba-VipAvailability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-threshold-Override_'), field('tags._amba-VipAvailability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-windowSize-Override_'), field('tags._amba-VipAvailability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-enabled-Override_'), field('tags._amba-VipAvailability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-evaluationFrequency-Override_'), field('tags._amba-VipAvailability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-windowSize-Override_'), field('tags._amba-VipAvailability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-severity-Override_'), field('tags._amba-VipAvailability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-VipAvailability-autoMitigate-Override_'), field('tags._amba-VipAvailability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_StorageAccount_Availability_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_StorageAccount_Availability_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Storage",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-autoMitigate-Override_'), field('tags._amba-Availability-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-enabled-Override_'), field('tags._amba-Availability-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-evaluationFrequency-Override_'), field('tags._amba-Availability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-severity-Override_'), field('tags._amba-Availability-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-threshold-Override_'), field('tags._amba-Availability-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-windowSize-Override_'), field('tags._amba-Availability-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-enabled-Override_'), field('tags._amba-Availability-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-evaluationFrequency-Override_'), field('tags._amba-Availability-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-windowSize-Override_'), field('tags._amba-Availability-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-severity-Override_'), field('tags._amba-Availability-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-Availability-autoMitigate-Override_'), field('tags._amba-Availability-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_TM_EndpointHealth_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_TM_EndpointHealth_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Networking",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-autoMitigate-Override_'), field('tags._amba-EndpointHealth-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-enabled-Override_'), field('tags._amba-EndpointHealth-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-evaluationFrequency-Override_'), field('tags._amba-EndpointHealth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-severity-Override_'), field('tags._amba-EndpointHealth-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-threshold-Override_'), field('tags._amba-EndpointHealth-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-windowSize-Override_'), field('tags._amba-EndpointHealth-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -290,23 +290,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-enabled-Override_'), field('tags._amba-EndpointHealth-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-evaluationFrequency-Override_'), field('tags._amba-EndpointHealth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-windowSize-Override_'), field('tags._amba-EndpointHealth-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-severity-Override_'), field('tags._amba-EndpointHealth-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-EndpointHealth-autoMitigate-Override_'), field('tags._amba-EndpointHealth-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VNET_DDoSAttack_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VNET_DDoSAttack_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-autoMitigate-Override_'), field('tags._amba-ifunderddosattack-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-enabled-Override_'), field('tags._amba-ifunderddosattack-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-evaluationFrequency-Override_'), field('tags._amba-ifunderddosattack-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-severity-Override_'), field('tags._amba-ifunderddosattack-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-threshold-Override_'), field('tags._amba-ifunderddosattack-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-windowSize-Override_'), field('tags._amba-ifunderddosattack-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-enabled-Override_'), field('tags._amba-ifunderddosattack-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-evaluationFrequency-Override_'), field('tags._amba-ifunderddosattack-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-windowSize-Override_'), field('tags._amba-ifunderddosattack-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-severity-Override_'), field('tags._amba-ifunderddosattack-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ifunderddosattack-autoMitigate-Override_'), field('tags._amba-ifunderddosattack-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VPNGw_BGPPeerStatus_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_BGPPeerStatus_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-autoMitigate-Override_'), field('tags._amba-bgppeerstatus-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-enabled-Override_'), field('tags._amba-bgppeerstatus-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-evaluationFrequency-Override_'), field('tags._amba-bgppeerstatus-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-severity-Override_'), field('tags._amba-bgppeerstatus-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-threshold-Override_'), field('tags._amba-bgppeerstatus-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-windowSize-Override_'), field('tags._amba-bgppeerstatus-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-enabled-Override_'), field('tags._amba-bgppeerstatus-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-evaluationFrequency-Override_'), field('tags._amba-bgppeerstatus-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-windowSize-Override_'), field('tags._amba-bgppeerstatus-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-severity-Override_'), field('tags._amba-bgppeerstatus-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-bgppeerstatus-autoMitigate-Override_'), field('tags._amba-bgppeerstatus-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VPNGw_BandwidthUtil_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_BandwidthUtil_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-autoMitigate-Override_'), field('tags._amba-tunnelaveragebandwidth-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-enabled-Override_'), field('tags._amba-tunnelaveragebandwidth-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-evaluationFrequency-Override_'), field('tags._amba-tunnelaveragebandwidth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-severity-Override_'), field('tags._amba-tunnelaveragebandwidth-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-threshold-Override_'), field('tags._amba-tunnelaveragebandwidth-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-windowSize-Override_'), field('tags._amba-tunnelaveragebandwidth-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-enabled-Override_'), field('tags._amba-tunnelaveragebandwidth-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-evaluationFrequency-Override_'), field('tags._amba-tunnelaveragebandwidth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-windowSize-Override_'), field('tags._amba-tunnelaveragebandwidth-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-severity-Override_'), field('tags._amba-tunnelaveragebandwidth-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelaveragebandwidth-autoMitigate-Override_'), field('tags._amba-tunnelaveragebandwidth-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VPNGw_Egress_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_Egress_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-autoMitigate-Override_'), field('tags._amba-tunnelegressbytes-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-enabled-Override_'), field('tags._amba-tunnelegressbytes-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-evaluationFrequency-Override_'), field('tags._amba-tunnelegressbytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-severity-Override_'), field('tags._amba-tunnelegressbytes-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-threshold-Override_'), field('tags._amba-tunnelegressbytes-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-windowSize-Override_'), field('tags._amba-tunnelegressbytes-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-enabled-Override_'), field('tags._amba-tunnelegressbytes-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-evaluationFrequency-Override_'), field('tags._amba-tunnelegressbytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-windowSize-Override_'), field('tags._amba-tunnelegressbytes-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-severity-Override_'), field('tags._amba-tunnelegressbytes-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelegressbytes-autoMitigate-Override_'), field('tags._amba-tunnelegressbytes-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VPNGw_Ingress_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_Ingress_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -148,13 +148,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-autoMitigate-Override_'), field('tags._amba-tunnelingressbytes-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-enabled-Override_'), field('tags._amba-tunnelingressbytes-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-evaluationFrequency-Override_'), field('tags._amba-tunnelingressbytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -163,13 +163,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-severity-Override_'), field('tags._amba-tunnelingressbytes-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-threshold-Override_'), field('tags._amba-tunnelingressbytes-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-windowSize-Override_'), field('tags._amba-tunnelingressbytes-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -284,23 +284,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-enabled-Override_'), field('tags._amba-tunnelingressbytes-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-evaluationFrequency-Override_'), field('tags._amba-tunnelingressbytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-windowSize-Override_'), field('tags._amba-tunnelingressbytes-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-severity-Override_'), field('tags._amba-tunnelingressbytes-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-tunnelingressbytes-autoMitigate-Override_'), field('tags._amba-tunnelingressbytes-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VPNGw_TunnelEgressPacketDropCount_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_TunnelEgressPacketDropCount_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropCount-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-severity-Override_'), field('tags._amba-TunnelEgressPacketDropCount-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropCount-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-severity-Override_'), field('tags._amba-TunnelEgressPacketDropCount-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-alertSensitivity-Override_'), field('tags._amba-TunnelEgressPacketDropCount-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VPNGw_TunnelEgressPacketDropMismatch_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_TunnelEgressPacketDropMismatch_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-alertSensitivity-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VPNGw_TunnelIngressPacketDropCount_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_TunnelIngressPacketDropCount_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropCount-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-severity-Override_'), field('tags._amba-TunnelIngressPacketDropCount-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropCount-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-severity-Override_'), field('tags._amba-TunnelIngressPacketDropCount-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-alertSensitivity-Override_'), field('tags._amba-TunnelIngressPacketDropCount-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VPNGw_TunnelIngressPacketDropMismatch_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VPNGw_TunnelIngressPacketDropMismatch_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-alertSensitivity-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VnetGw_ExpressRouteBitsPerSecond_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_ExpressRouteBitsPerSecond_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-enabled-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-severity-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-enabled-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-severity-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayBitsPerSecond-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayBitsPerSecond-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VnetGw_ExpressRouteCpuUtil_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_ExpressRouteCpuUtil_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-threshold-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), field('tags._amba-ExpressRouteGatewayCpuUtilization-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VnetGw_TunnelBandwidth_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_TunnelBandwidth_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-autoMitigate-Override_'), field('tags._amba-TunnelAverageBandwidth-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-enabled-Override_'), field('tags._amba-TunnelAverageBandwidth-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-evaluationFrequency-Override_'), field('tags._amba-TunnelAverageBandwidth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-severity-Override_'), field('tags._amba-TunnelAverageBandwidth-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-threshold-Override_'), field('tags._amba-TunnelAverageBandwidth-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-windowSize-Override_'), field('tags._amba-TunnelAverageBandwidth-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-enabled-Override_'), field('tags._amba-TunnelAverageBandwidth-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-evaluationFrequency-Override_'), field('tags._amba-TunnelAverageBandwidth-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-windowSize-Override_'), field('tags._amba-TunnelAverageBandwidth-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-severity-Override_'), field('tags._amba-TunnelAverageBandwidth-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelAverageBandwidth-autoMitigate-Override_'), field('tags._amba-TunnelAverageBandwidth-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VnetGw_TunnelEgressPacketDropCount_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_TunnelEgressPacketDropCount_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.5.1"
+      "version": "1.5.3"
     },
     "mode": "All",
     "parameters": {
@@ -160,19 +160,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropCount-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -181,10 +181,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-severity-Override_'), field('tags._amba-TunnelEgressPacketDropCount-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -309,23 +309,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropCount-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-severity-Override_'), field('tags._amba-TunnelEgressPacketDropCount-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -337,15 +337,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-alertSensitivity-Override_'), field('tags._amba-TunnelEgressPacketDropCount-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VnetGw_TunnelEgressPacketDropMismatch_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_TunnelEgressPacketDropMismatch_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.5.1"
+      "version": "1.5.3"
     },
     "mode": "All",
     "parameters": {
@@ -160,19 +160,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -181,10 +181,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -309,23 +309,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -337,15 +337,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-alertSensitivity-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelEgressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VnetGw_TunnelEgress_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_TunnelEgress_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-autoMitigate-Override_'), field('tags._amba-TunnelEgressBytes-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-enabled-Override_'), field('tags._amba-TunnelEgressBytes-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressBytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-severity-Override_'), field('tags._amba-TunnelEgressBytes-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-threshold-Override_'), field('tags._amba-TunnelEgressBytes-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-windowSize-Override_'), field('tags._amba-TunnelEgressBytes-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-enabled-Override_'), field('tags._amba-TunnelEgressBytes-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-evaluationFrequency-Override_'), field('tags._amba-TunnelEgressBytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-windowSize-Override_'), field('tags._amba-TunnelEgressBytes-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-severity-Override_'), field('tags._amba-TunnelEgressBytes-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelEgressBytes-autoMitigate-Override_'), field('tags._amba-TunnelEgressBytes-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_VnetGw_TunnelIngressPacketDropCount_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_TunnelIngressPacketDropCount_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.5.1"
+      "version": "1.5.3"
     },
     "mode": "All",
     "parameters": {
@@ -160,19 +160,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropCount-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -181,10 +181,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-severity-Override_'), field('tags._amba-TunnelIngressPacketDropCount-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -309,23 +309,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropCount-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropCount-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-severity-Override_'), field('tags._amba-TunnelIngressPacketDropCount-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropCount-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -337,15 +337,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-alertSensitivity-Override_'), field('tags._amba-TunnelIngressPacketDropCount-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropCount-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VnetGw_TunnelIngressPacketDropMismatch_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_TunnelIngressPacketDropMismatch_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.5.1"
+      "version": "1.5.3"
     },
     "mode": "All",
     "parameters": {
@@ -160,19 +160,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -181,10 +181,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -309,23 +309,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -337,15 +337,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-alertSensitivity-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), field('tags._amba-TunnelIngressPacketDropTSMismatch-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_VnetGw_TunnelIngress_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_VnetGw_TunnelIngress_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Network",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -152,13 +152,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-autoMitigate-Override_'), field('tags._amba-TunnelIngressBytes-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-enabled-Override_'), field('tags._amba-TunnelIngressBytes-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressBytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -167,13 +167,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-severity-Override_'), field('tags._amba-TunnelIngressBytes-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-threshold-Override_'), field('tags._amba-TunnelIngressBytes-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-windowSize-Override_'), field('tags._amba-TunnelIngressBytes-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -288,23 +288,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-enabled-Override_'), field('tags._amba-TunnelIngressBytes-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-evaluationFrequency-Override_'), field('tags._amba-TunnelIngressBytes-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-windowSize-Override_'), field('tags._amba-TunnelIngressBytes-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-severity-Override_'), field('tags._amba-TunnelIngressBytes-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-TunnelIngressBytes-autoMitigate-Override_'), field('tags._amba-TunnelIngressBytes-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_WSF_CPUPercentage_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_WSF_CPUPercentage_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Web Services",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-autoMitigate-Override_'), field('tags._amba-CpuPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-enabled-Override_'), field('tags._amba-CpuPercentage-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-evaluationFrequency-Override_'), field('tags._amba-CpuPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-severity-Override_'), field('tags._amba-CpuPercentage-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-threshold-Override_'), field('tags._amba-CpuPercentage-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-windowSize-Override_'), field('tags._amba-CpuPercentage-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-enabled-Override_'), field('tags._amba-CpuPercentage-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-evaluationFrequency-Override_'), field('tags._amba-CpuPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-windowSize-Override_'), field('tags._amba-CpuPercentage-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-severity-Override_'), field('tags._amba-CpuPercentage-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-CpuPercentage-autoMitigate-Override_'), field('tags._amba-CpuPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {

--- a/platform/amba/policy_definitions/Deploy_WSF_DiskQueueLength_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_WSF_DiskQueueLength_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Web Services",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-autoMitigate-Override_'), field('tags._amba-DiskQueueLength-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-enabled-Override_'), field('tags._amba-DiskQueueLength-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-evaluationFrequency-Override_'), field('tags._amba-DiskQueueLength-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-evaluationPeriods-Override_'), field('tags._amba-DiskQueueLength-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-failingPeriods-Override_'), field('tags._amba-DiskQueueLength-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-severity-Override_'), field('tags._amba-DiskQueueLength-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-windowSize-Override_'), field('tags._amba-DiskQueueLength-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-enabled-Override_'), field('tags._amba-DiskQueueLength-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-evaluationFrequency-Override_'), field('tags._amba-DiskQueueLength-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-windowSize-Override_'), field('tags._amba-DiskQueueLength-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-severity-Override_'), field('tags._amba-DiskQueueLength-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-autoMitigate-Override_'), field('tags._amba-DiskQueueLength-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-alertSensitivity-Override_'), field('tags._amba-DiskQueueLength-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-failingPeriods-Override_'), field('tags._amba-DiskQueueLength-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-DiskQueueLength-evaluationPeriods-Override_'), field('tags._amba-DiskQueueLength-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_WSF_HttpQueueLength_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_WSF_HttpQueueLength_Alert.alz_policy_definition.json
@@ -10,7 +10,7 @@
       ],
       "category": "Web Services",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.3"
     },
     "mode": "All",
     "parameters": {
@@ -156,19 +156,19 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-autoMitigate-Override_'), field('tags._amba-HttpQueueLength-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-enabled-Override_'), field('tags._amba-HttpQueueLength-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-evaluationFrequency-Override_'), field('tags._amba-HttpQueueLength-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "evaluationPeriods": {
-                  "value": "[parameters('evaluationPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-evaluationPeriods-Override_'), field('tags._amba-HttpQueueLength-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]"
                 },
                 "failingPeriods": {
-                  "value": "[parameters('failingPeriods')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-failingPeriods-Override_'), field('tags._amba-HttpQueueLength-failingPeriods-Override_'), parameters('failingPeriods'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -177,10 +177,10 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-severity-Override_'), field('tags._amba-HttpQueueLength-severity-Override_'), parameters('severity'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-windowSize-Override_'), field('tags._amba-HttpQueueLength-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -305,23 +305,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-enabled-Override_'), field('tags._amba-HttpQueueLength-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-evaluationFrequency-Override_'), field('tags._amba-HttpQueueLength-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-windowSize-Override_'), field('tags._amba-HttpQueueLength-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-severity-Override_'), field('tags._amba-HttpQueueLength-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-autoMitigate-Override_'), field('tags._amba-HttpQueueLength-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {
@@ -333,15 +333,15 @@
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.operator"
               },
               {
-                "equals": "Medium",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-alertSensitivity-Override_'), field('tags._amba-HttpQueueLength-alertSensitivity-Override_'), parameters('alertSensitivity'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.alertSensitivity"
               },
               {
-                "equals": "[parameters('failingPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-failingPeriods-Override_'), field('tags._amba-HttpQueueLength-failingPeriods-Override_'), parameters('failingPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.minFailingPeriodsToAlert"
               },
               {
-                "equals": "[parameters('evaluationPeriods')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-HttpQueueLength-evaluationPeriods-Override_'), field('tags._amba-HttpQueueLength-evaluationPeriods-Override_'), parameters('evaluationPeriods'))]",
                 "field": "Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-MultipleResourceMultipleMetricCriteria.allOf[*].DynamicThresholdCriterion.failingPeriods.numberOfEvaluationPeriods"
               }
             ]

--- a/platform/amba/policy_definitions/Deploy_WSF_MemoryPercentage_Alert.alz_policy_definition.json
+++ b/platform/amba/policy_definitions/Deploy_WSF_MemoryPercentage_Alert.alz_policy_definition.json
@@ -7,7 +7,7 @@
       "_deployed_by_amba": "True",
       "category": "Web Services",
       "source": "https://github.com/Azure/azure-monitor-baseline-alerts/",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     "mode": "All",
     "parameters": {
@@ -145,13 +145,13 @@
               "mode": "incremental",
               "parameters": {
                 "autoMitigate": {
-                  "value": "[parameters('autoMitigate')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-autoMitigate-Override_'), field('tags._amba-MemoryPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]"
                 },
                 "enabled": {
-                  "value": "[parameters('enabled')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-enabled-Override_'), field('tags._amba-MemoryPercentage-enabled-Override_'), parameters('enabled'))]"
                 },
                 "evaluationFrequency": {
-                  "value": "[parameters('evaluationFrequency')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-evaluationFrequency-Override_'), field('tags._amba-MemoryPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]"
                 },
                 "resourceId": {
                   "value": "[field('id')]"
@@ -160,13 +160,13 @@
                   "value": "[field('name')]"
                 },
                 "severity": {
-                  "value": "[parameters('severity')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-severity-Override_'), field('tags._amba-MemoryPercentage-severity-Override_'), parameters('severity'))]"
                 },
                 "threshold": {
                   "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-threshold-Override_'), field('tags._amba-MemoryPercentage-threshold-Override_'), parameters('threshold'))]"
                 },
                 "windowSize": {
-                  "value": "[parameters('windowSize')]"
+                  "value": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-windowSize-Override_'), field('tags._amba-MemoryPercentage-windowSize-Override_'), parameters('windowSize'))]"
                 }
               },
               "template": {
@@ -281,23 +281,23 @@
                 "field": "Microsoft.Insights/metricalerts/scopes[*]"
               },
               {
-                "equals": "[parameters('enabled')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-enabled-Override_'), field('tags._amba-MemoryPercentage-enabled-Override_'), parameters('enabled'))]",
                 "field": "Microsoft.Insights/metricAlerts/enabled"
               },
               {
-                "equals": "[parameters('evaluationFrequency')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-evaluationFrequency-Override_'), field('tags._amba-MemoryPercentage-evaluationFrequency-Override_'), parameters('evaluationFrequency'))]",
                 "field": "Microsoft.Insights/metricAlerts/evaluationFrequency"
               },
               {
-                "equals": "[parameters('windowSize')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-windowSize-Override_'), field('tags._amba-MemoryPercentage-windowSize-Override_'), parameters('windowSize'))]",
                 "field": "Microsoft.Insights/metricAlerts/windowSize"
               },
               {
-                "equals": "[parameters('severity')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-severity-Override_'), field('tags._amba-MemoryPercentage-severity-Override_'), parameters('severity'))]",
                 "field": "Microsoft.Insights/metricalerts/severity"
               },
               {
-                "equals": "[parameters('autoMitigate')]",
+                "equals": "[if(contains(coalesce(field('tags'), createObject()), '_amba-MemoryPercentage-autoMitigate-Override_'), field('tags._amba-MemoryPercentage-autoMitigate-Override_'), parameters('autoMitigate'))]",
                 "field": "Microsoft.Insights/metricAlerts/autoMitigate"
               },
               {


### PR DESCRIPTION
Extends the existing _amba-<metric>-threshold-Override_ tag pattern to cover all remaining tunable metric alert parameters:

  - severity             (_amba-<metric>-severity-Override_)
  - enabled              (_amba-<metric>-enabled-Override_)
  - evaluationFrequency  (_amba-<metric>-evaluationFrequency-Override_)
  - windowSize           (_amba-<metric>-windowSize-Override_)
  - autoMitigate         (_amba-<metric>-autoMitigate-Override_)

Dynamic-threshold alert definitions also gain:
  - alertSensitivity     (_amba-<metric>-alertSensitivity-Override_)
  - evaluationPeriods    (_amba-<metric>-evaluationPeriods-Override_)
  - failingPeriods       (_amba-<metric>-failingPeriods-Override_)

For each parameter the ARM if(contains(coalesce(field('tags'),...))) expression is applied in two places per policy definition:
  1. deployment.properties.parameters - controls what value gets deployed
  2. existenceCondition.allOf         - ensures remediation respects the tag

Applies to all 85 metric alert policy definitions (Microsoft.Insights/metricAlerts). alertSensitivity/evaluationPeriods/failingPeriods additionally applied to the 21 dynamic-threshold files where those parameters exist. Log and activity-log alert definitions are unchanged; their alert rules are subscription-scoped, making per-resource parameter overrides inapplicable.

Motivation: without these overrides, a remediation task overwrites any manual per-resource alert customisation (e.g. silencing a single noisy alert on a specific resource, or marking a critical resource as sev-0) and resets it to the fleet-wide policy assignment defaults. The enabled tag also fills a gap where MonitorDisableTagName disables ALL AMBA alerts on a resource, whereas _amba-<metric>-enabled-Override_ = false targets a single specific alert.

Note: evaluationPeriods and failingPeriods are coupled — Azure Monitor requires minFailingPeriodsToAlert <= numberOfEvaluationPeriods. If you override one, set both.

Bug fix (included): 13 dynamic-threshold policy definitions had a hardcoded literal "Medium" string in their existenceCondition instead of a [parameters('alertSensitivity')] reference. This caused perpetual non-compliant state regardless of the assigned alertSensitivity value. Fixed as part of this change.

Bumps patch version of all modified policy definitions.