### PR TITLE
docs: removing Deploy-SvcHealth-BuiltIn via archetype override when adopting AMBA (#4210)

### DIFF
--- a/docs/content/assets/archetype-overrides.md
+++ b/docs/content/assets/archetype-overrides.md
@@ -63,3 +63,42 @@ management_groups:
     parent_id: my-mg
     exists: false
 ```
+
+## Example: adopting AMBA alongside ALZ
+
+When you deploy [Azure Monitor Baseline Alerts (AMBA)](https://github.com/Azure/Azure-Landing-Zones-Library/tree/main/platform/amba) on top of the ALZ archetypes, AMBA's `Deploy-AMBA-Res-SvcHlth` assignment provides Service Health alerting for your landing zones.
+
+The ALZ `root` archetype also assigns `Deploy-SvcHealth-BuiltIn`, which targets the **same** underlying built-in Service Health policy. When both are deployed together they each run their own remediation, resulting in **duplicate action groups and duplicate Service Health alert rules** (for example, in `rg-serviceHealthAlert` and `rg-amba-monitoring-001`).
+
+To avoid this overlap, remove `Deploy-SvcHealth-BuiltIn` from your ALZ `root` archetype using a local archetype override, and let AMBA own Service Health alerting:
+
+```yaml
+name: "root_amba_override"
+base_archetype: "root"
+policy_assignments_to_add: []
+policy_assignments_to_remove:
+  - "Deploy-SvcHealth-BuiltIn"
+policy_definitions_to_add: []
+policy_definitions_to_remove: []
+policy_set_definitions_to_add: []
+policy_set_definitions_to_remove: []
+role_definitions_to_add: []
+role_definitions_to_remove: []
+```
+
+Then reference the override in your architecture definition in place of `root`:
+
+```yaml
+name: my architecture
+management_groups:
+  - id: my-mg
+    display_name: My Management Group
+    archetypes:
+      - root_amba_override # Use the override instead of "root" when adopting AMBA
+    parent_id: null
+    exists: false
+```
+
+{{< hint type=note >}}
+Only remove `Deploy-SvcHealth-BuiltIn` when you are actually deploying AMBA's Service Health alerting. If you are **not** using AMBA, keep the built-in assignment so you retain default Service Health alerting.
+{{< /hint >}}


### PR DESCRIPTION
## Overview

Documents how to avoid duplicate Service Health action groups and alert rules when deploying [AMBA](https://github.com/Azure/Azure-Landing-Zones-Library/tree/main/platform/amba) on top of the ALZ archetypes.

## Background

The ALZ `root` archetype assigns `Deploy-SvcHealth-BuiltIn`, and AMBA's `Deploy-AMBA-Res-SvcHlth` initiative member references the **same** underlying built-in Service Health policy. When both are deployed together, each runs its own DINE remediation, producing **duplicate action groups and Service Health alert rules** (e.g. in `rg-serviceHealthAlert` and `rg-amba-monitoring-001`).

Rather than removing `Deploy-SvcHealth-BuiltIn` from the base archetype for **all** Library consumers — which would regress non-AMBA environments that rely on it for default Service Health alerting — this documents the per-consumer opt-out.

## Change

Adds an *"Adopting AMBA alongside ALZ"* example to the **Archetype Overrides** page (`docs/content/assets/archetype-overrides.md`) showing how to:

- Remove `Deploy-SvcHealth-BuiltIn` from the ALZ `root` archetype via a local `*.alz_archetype_override` file.
- Wire the override into the architecture definition.

Includes a note that the assignment should only be removed when AMBA is actually deployed, so non-AMBA consumers keep default Service Health alerting.

## Validation

- Docs-only change; no library assets or generated files modified.
- Follows the existing archetype-override pattern already documented on the same page.
