### PR TITLE
docs: correct supported file formats for library assets

### DIFF
--- a/docs/content/assets/_index.md
+++ b/docs/content/assets/_index.md
@@ -42,3 +42,20 @@ A library memebr may extend another, if this is the case then the dependency inf
 
 - [**Policy Default Values**](/Azure-Landing-Zones-Library/assets/policy-default-values): It is common to want to pass the same value into multiple policy assignments.
 For example, a default Log Analytics workspace id. This construct allows you to define a default value that can be referenced by many policy assignments, for specific parameters.
+
+## Supported file formats
+
+Assets that represent Azure resources are JSON only, as the Azure Resource Manager APIs are JSON based.
+Library constructs may also be supplied as YAML.
+
+| Asset | JSON | YAML |
+| --- | --- | --- |
+| [Policy Definitions](/Azure-Landing-Zones-Library/assets/policy-definitions) | Yes | No |
+| [Policy Set Definitions](/Azure-Landing-Zones-Library/assets/policy-set-definitions) | Yes | No |
+| [Policy Assignments](/Azure-Landing-Zones-Library/assets/policy-assignments) | Yes | No |
+| [Role Definitions](/Azure-Landing-Zones-Library/assets/role-definitions) | Yes | No |
+| [Archetypes](/Azure-Landing-Zones-Library/assets/archetypes) | Yes | Yes |
+| [Archetype Overrides](/Azure-Landing-Zones-Library/assets/archetype-overrides) | Yes | Yes |
+| [Architectures](/Azure-Landing-Zones-Library/assets/architectures) | Yes | Yes |
+| [Policy Default Values](/Azure-Landing-Zones-Library/assets/policy-default-values) | Yes | Yes |
+| [Metadata](/Azure-Landing-Zones-Library/assets/metadata) | Yes | No |

--- a/docs/content/assets/role-definitions.md
+++ b/docs/content/assets/role-definitions.md
@@ -8,12 +8,10 @@ geekdocAnchor: true
 Filename patterns:
 
 - `*.alz_role_definition.json`
-- `*.alz_role_definition.yaml`
-- `*.alz_role_definition.yml`
 
 These files represent Azure role definitions.
 They are files that represent the resource definition as per the schema.
-Although the Azure Resource Manager APIs use JSON, the library supports both JSON and YAML formats.
+The file type is JSON.
 Any keys that are not part of the schema should be ignored.
 
 Within the resource definition, there are several values that specific to the scope of the deployed resource and must be modified when the assignment is deployed in an architecture.


### PR DESCRIPTION
Role definitions are documented as accepting both JSON and YAML, but they are an Azure resource type and only JSON is supported. The other Azure resource pages (policy definitions, policy set definitions, policy assignments) already state `The file type is JSON`, so this aligns the role definitions page with them.

This also adds a supported file formats table to the assets index, so the JSON-only versus JSON and YAML distinction is stated in one place rather than inferred page by page. The split follows whether an asset maps to an Azure Resource Manager resource or is a library construct.

Related: Azure/alzlib#247
